### PR TITLE
Include support for perl packages

### DIFF
--- a/livecheck/special/metacpan.py
+++ b/livecheck/special/metacpan.py
@@ -1,0 +1,28 @@
+import requests
+
+from loguru import logger
+
+__all__ = ("def get_latest_metacpan_package",)
+
+
+def get_latest_metacpan_package(package_name: str) -> tuple[str, str]:
+    api_url = f"https://fastapi.metacpan.org/v1/release/{package_name}"
+
+    try:
+        response = requests.get(api_url)
+        response.raise_for_status()  # Lanza un error si la solicitud falla
+
+        release_info = response.json()
+
+        latest_version = release_info.get('version')
+        download_url = release_info.get('download_url')
+
+        if latest_version and download_url:
+            return latest_version, download_url
+
+        logger.debug(f"Version information not found for {package_name}.")
+
+    except requests.exceptions.HTTPError as e:
+        logger.debug(f"Error accessing the URL: {e}")
+
+    return '', ''

--- a/livecheck/special/pecl.py
+++ b/livecheck/special/pecl.py
@@ -3,7 +3,7 @@ import re
 
 from loguru import logger
 
-__all__ = ("check_for_new_version_from_pecl",)
+__all__ = ("get_latest_pecl_package",)
 
 
 def get_last_filename(url: str) -> str:
@@ -28,7 +28,7 @@ def get_last_filename(url: str) -> str:
         return ''
 
 
-def check_for_new_version_from_pecl(program_name: str, current_version: str) -> tuple[str, str]:
+def get_latest_pecl_package(program_name: str) -> tuple[str, str]:
     # Remove 'pecl-' prefix if present
     if program_name.startswith('pecl-'):
         program_name = program_name.replace('pecl-', '', 1)


### PR DESCRIPTION
unify the names better, because you really get the latest version or the new version
Fix the problem when version or top_hash is 1.8 

<pre>
  File "/home/fran/projectos/livecheck/livecheck/__main__.py", line 3, in <module>
    main()
  File "/usr/lib/python3.12/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/fran/projectos/livecheck/livecheck/main.py", line 498, in main
    do_main(r=r,
  File "/home/fran/projectos/livecheck/livecheck/main.py", line 335, in do_main
    version = sanitize_version(version)
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/fran/projectos/livecheck/livecheck/main.py", line 71, in sanitize_version
    match = re.search(pattern, version)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/re/__init__.py", line 177, in search
    return _compile(pattern, flags).search(string)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: expected string or bytes-like object, got 'float'
</pre>