### PR TITLE
use "match-all" instead of "match-visible"

### DIFF
--- a/livecheck/special/dotnet.py
+++ b/livecheck/special/dotnet.py
@@ -62,7 +62,7 @@ def update_dotnet_ebuild(ebuild: str | Path, project_or_solution: str | Path, cp
     with tempfile.TemporaryDirectory(prefix='livecheck-dotnet-', ignore_cleanup_errors=True) as td:
         sp.run(('ebuild', str(ebuild), 'manifest'), check=True)
         matches = list(
-            unique_justseen(sorted(set(P.xmatch('match-visible', cp)), key=cmp_to_key(sort_by_v)),
+            unique_justseen(sorted(set(P.xmatch('match-all', cp)), key=cmp_to_key(sort_by_v)),
                             key=lambda a: catpkg_catpkgsplit(a)[0]))
         if not matches:
             raise NoMatch(cp)

--- a/livecheck/utils/portage.py
+++ b/livecheck/utils/portage.py
@@ -41,7 +41,7 @@ def get_highest_matches(search_dir: str, repo_root: str) -> Iterator[str]:
     for path in Path(search_dir).glob('**/*.ebuild'):
         dn = path.parent
         name = f'{dn.parent.name}/{dn.name}'
-        if matches := P.xmatch('match-visible', name):
+        if matches := P.xmatch('match-all', name):
             for m in matches:
                 if P.findname2(m)[1] == repo_root:
                     yield m
@@ -49,7 +49,7 @@ def get_highest_matches(search_dir: str, repo_root: str) -> Iterator[str]:
 
 def get_highest_matches2(names: Sequence[str], search_dir: str) -> Iterator[str]:
     for name in names:
-        if matches := P.xmatch('match-visible', name):
+        if matches := P.xmatch('match-all', name):
             for m in matches:
                 candidate = P.findname2(m)[1]
                 logger.debug('Checking: %s == %s ?', candidate, search_dir)


### PR DESCRIPTION
When I was testing with different jetbrains ebuilds I realized that sometimes it selects in the search, as an example: 
python -m livecheck -W /usr/portage/dev-util/clion/ -d
without the patch

<pre>
2024-10-05 16:56:34.932 | DEBUG    | livecheck.main:get_props:126 - search_dir=/usr/portage/dev-util/clion repo_root=/usr/portage repo_name=portage
DEBUG:asyncio:Using selector: EpollSelector
2024-10-05 16:56:34.936 | DEBUG    | livecheck.main:get_props:141 - Found 0 ebuilds
2024-10-05 16:56:34.936 | ERROR    | livecheck.main:get_props:143 - No matches!
Aborted!
</pre>

After this patch + patch #202
<pre>
2024-10-05 16:59:15.419 | DEBUG    | livecheck.main:get_props:126 - search_dir=/usr/portage/dev-util/clion repo_root=/usr/portage repo_name=portage
DEBUG:asyncio:Using selector: EpollSelector
DEBUG:livecheck.utils.portage:Found multiple ebuilds of dev-util/clion. Only the highest version ebuild will be considered.
DEBUG:livecheck.utils.portage:Found multiple ebuilds of dev-util/clion. Only the highest version ebuild will be considered.
DEBUG:livecheck.utils.portage:Found multiple ebuilds of dev-util/clion. Only the highest version ebuild will be considered.
DEBUG:livecheck.utils.portage:Found multiple ebuilds of dev-util/clion. Only the highest version ebuild will be considered.
DEBUG:livecheck.utils.portage:Found multiple ebuilds of dev-util/clion. Only the highest version ebuild will be considered.
2024-10-05 16:59:15.422 | DEBUG    | livecheck.main:get_props:141 - Found 1 ebuilds
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): data.services.jetbrains.com:443
DEBUG:urllib3.connectionpool:https://data.services.jetbrains.com:443 "GET /products HTTP/11" 200 None
2024-10-05 16:59:16.463 | DEBUG    | livecheck.main:main:482 - Fetching https://download.jetbrains.com/cpp/CLion-2024.2.2.tar.gz
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): download.jetbrains.com:443
DEBUG:urllib3.connectionpool:https://download.jetbrains.com:443 "GET /cpp/CLion-2024.2.2.tar.gz HTTP/11" 302 138
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): download-cdn.jetbrains.com:443
DEBUG:urllib3.connectionpool:https://download-cdn.jetbrains.com:443 "GET /cpp/CLion-2024.2.2.tar.gz HTTP/11" 200 1425685720
2024-10-05 16:59:29.586 | DEBUG    | livecheck.main:do_main:354 - Result count: 1
2024-10-05 16:59:29.586 | DEBUG    | livecheck.main:do_main:363 - re.findall() -> "2024.2.2"
2024-10-05 16:59:29.587 | DEBUG    | livecheck.main:do_main:380 - Attempted to fix top_hash date but it failed. Ignoring this error.
2024-10-05 16:59:29.587 | DEBUG    | livecheck.main:do_main:381 - top_hash = 2024.2.2
2024-10-05 16:59:29.587 | DEBUG    | livecheck.main:do_main:382 - Comparing current ebuild version 2024.1 with live version 2024.2.2
dev-util/clion: 2024.1 -> 2024.2.2
</pre>