### PR TITLE
Permitr search in SCR_URI a valid URI

### DIFF
--- a/livecheck/utils/portage.py
+++ b/livecheck/utils/portage.py
@@ -119,7 +119,11 @@ def catpkg_catpkgsplit(atom: str) -> tuple[str, str, str, str]:
 
 
 def get_first_src_uri(match: str, search_dir: str | None = None) -> str:
-    return P.aux_get(match, ['SRC_URI'], mytree=search_dir)[0].split(' ')[0]
+    for uri in P.aux_get(match, ['SRC_URI'], mytree=search_dir):
+        for line in uri.split():
+            if line.startswith(('http://', 'https://')):
+                return line
+    return ''
 
 
 def get_repository_root_if_inside(directory: str) -> tuple[str, str]:


### PR DESCRIPTION
When a ebuild have multiple sources by arches, for example
<pre>
DESCRIPTION="general puppet client utils along with hiera and facter"                                                                                                                                                                                              
HOMEPAGE="https://puppetlabs.com/"                                                                                                                                                                                                                                 
SRC_URI="amd64? ( http://apt.puppetlabs.com/pool/focal/puppet8/${PN:0:1}/${PN}/${PN}_${PV}-1focal_amd64.deb )                                                                                                                                                      
arm64? ( http://apt.puppetlabs.com/pool/focal/puppet8/${PN:0:1}/${PN}/${PN}_${PV}-1focal_arm64.deb )"                                                                                                                                                              
</pre>

python -m livecheck -W /usr/portage/app-arch/upx-bin  -d

Before
<pre>
2024-10-05 17:21:08.612 | DEBUG    | livecheck.main:get_props:126 - search_dir=/usr/portage/app-arch/upx-bin repo_root=/usr/portage repo_name=portage
DEBUG:asyncio:Using selector: EpollSelector
2024-10-05 17:21:08.616 | DEBUG    | livecheck.main:get_props:141 - Found 1 ebuilds
2024-10-05 17:21:08.617 | DEBUG    | livecheck.main:get_props:282 - Unhandled: app-arch/upx-bin None
2024-10-05 17:21:08.617 | DEBUG    | livecheck.main:log_unhandled_pkg:110 - Not handled: app-arch/upx-bin (checksum), homepage: https://upx.github.io/, SRC_URI: x86?
</pre>

After
<pre>
2024-10-05 17:24:04.586 | DEBUG    | livecheck.main:get_props:126 - search_dir=/usr/portage/app-arch/upx-bin repo_root=/usr/portage repo_name=portage
DEBUG:asyncio:Using selector: EpollSelector
2024-10-05 17:24:04.590 | DEBUG    | livecheck.main:get_props:141 - Found 1 ebuilds
2024-10-05 17:24:04.590 | DEBUG    | livecheck.main:get_props:191 - Parsed path: /upx/upx/releases/download/v4.1.0/upx-4.1.0-i386_linux.tar.xz
2024-10-05 17:24:04.590 | DEBUG    | livecheck.main:main:489 - Fetching https://github.com/upx/upx/tags
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): github.com:443
DEBUG:urllib3.connectionpool:https://github.com:443 "GET /upx/upx/tags HTTP/11" 200 None
2024-10-05 17:24:05.016 | DEBUG    | livecheck.main:do_main:350 - Using RE: "archive/refs/tags/v([^"]+)\.tar\.gz"
2024-10-05 17:24:05.016 | DEBUG    | livecheck.main:do_main:353 - Adjusting RE for semantic versioning
2024-10-05 17:24:05.016 | DEBUG    | livecheck.main:do_main:357 - Adjusted RE: archive/refs/tags/vv?(\d+\.\d+(?:\.\d+)?)\.tar\.gz
2024-10-05 17:24:05.016 | DEBUG    | livecheck.main:do_main:361 - Result count: 10
2024-10-05 17:24:05.016 | DEBUG    | livecheck.main:do_main:370 - re.findall() -> "4.2.4"
2024-10-05 17:24:05.017 | DEBUG    | livecheck.main:do_main:387 - Attempted to fix top_hash date but it failed. Ignoring this error.
2024-10-05 17:24:05.017 | DEBUG    | livecheck.main:do_main:388 - top_hash = 4.2.4
2024-10-05 17:24:05.017 | DEBUG    | livecheck.main:do_main:389 - Comparing current ebuild version 4.1.0 with live version 4.2.4
app-arch/upx-bin: 4.1.0 -> 4.2.4
</pre>
