### PR TITLE
Fix error when errors in livecheck.json

### DIFF
--- a/livecheck/settings.py
+++ b/livecheck/settings.py
@@ -58,7 +58,11 @@ def gather_settings(search_dir: str) -> LivecheckSettings:
         with path.open() as f:
             dn = path.parent
             catpkg = f'{dn.parent.name}/{dn.name}'
-            settings_parsed = json.load(f)
+            try:
+                settings_parsed = json.load(f)
+            except json.JSONDecodeError as e:
+                logger.error('Error parsing file %s: %s', path, e)
+                continue
             if settings_parsed.get('type') == 'none':
                 ignored_packages.add(catpkg)
             elif settings_parsed.get('type') == 'regex':


### PR DESCRIPTION
Fix this error
<pre>
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/fran/projectos/livecheck/livecheck/__main__.py", line 3, in <module>
    main()
  File "/usr/lib/python3.12/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/fran/projectos/livecheck/livecheck/main.py", line 478, in main
    settings = gather_settings(search_dir)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/fran/projectos/livecheck/livecheck/settings.py", line 61, in gather_settings
    settings_parsed = json.load(f)
                      ^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/__init__.py", line 293, in load
    return loads(fp.read(),
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
               ^^^^^^^^^^^^^^^^^^^^^^
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 3 column 1 (char 20)
</pre>