### PR TITLE
Improves comparison between versions

### DIFF
--- a/livecheck/main.py
+++ b/livecheck/main.py
@@ -16,7 +16,6 @@ import xml.etree.ElementTree as etree
 import os
 
 from loguru import logger
-from portage.versions import vercmp
 from portage.exception import InvalidAtom
 from requests import ConnectTimeout, ReadTimeout
 import click
@@ -60,24 +59,11 @@ from .utils.portage import (
     get_highest_matches2,
     sort_by_v,
     get_repository_root_if_inside,
+    sanitize_version,
+    compare_versions,
 )
 
 T = TypeVar('T')
-
-
-# Sanitize version to Gentoo Ebuild format
-# info: https://dev.gentoo.org/~gokturk/devmanual/pr65/ebuild-writing/file-format/index.html
-def sanitize_version(version: str) -> str:
-    pattern = r"(\d+(\.\d+)*[a-z]?(_(alpha|beta|pre|rc|p)\d*)*(-r\d+)?)"
-
-    match = re.search(pattern, version)
-
-    if match:
-        if match.group(1) != version:
-            logger.warning(f'Version {version} sanitized to {match.group(1)}')
-        return match.group(1)
-    else:
-        return version
 
 
 def process_submodules(pkg_name: str, ref: str, contents: str, repo_uri: str) -> str:
@@ -281,10 +267,6 @@ def get_props(search_dir: str,
             log_unhandled_pkg(catpkg, home, src_uri)
 
 
-def special_vercmp(x: str, y: str) -> int:
-    return 1 if (ret := vercmp(x, y)) is None else ret
-
-
 def log_expected_sha_line() -> None:
     logger.debug('Expected SHA line to be present')
 
@@ -328,9 +310,6 @@ def do_main(*, auto_update: bool, cat: str, ebuild_version: str, parsed_uri: Par
     cp = f'{cat}/{pkg}'
     prefixes: dict[str, str] | None = None
     if not regex:
-        # Force convert version to string to fix version like 1.8
-        version = str(version)
-        version = sanitize_version(version)
         results = [version]
         version = ebuild_version
     else:
@@ -348,14 +327,9 @@ def do_main(*, auto_update: bool, cat: str, ebuild_version: str, parsed_uri: Par
     if tf := settings.transformations.get(cp, None):
         results = [tf(x) for x in results]
     logger.debug(f'Result count: {len(results)}')
-    try:
-        top_hash = (sorted(results, key=cmp_to_key(special_vercmp), reverse=True)
-                    if use_vercmp else results)[0]
-    except IndexError:
-        logger.warning(f'Attempted to fix top_hash version but it failed in {cp}')
+    if len(results) == 0:
         return
-    # Convert top_hash to string always to fix version like 1.8
-    top_hash = str(top_hash)
+    top_hash = results[0]
     logger.debug(f're.findall() -> "{top_hash}"')
     if update_sha_too_source := settings.sha_sources.get(cp, None):
         logger.debug('Package also needs a SHA update')
@@ -376,9 +350,8 @@ def do_main(*, auto_update: bool, cat: str, ebuild_version: str, parsed_uri: Par
             logger.debug('Attempted to fix top_hash date but it failed. Ignoring this error.')
     logger.debug(f'top_hash = {top_hash}')
     logger.debug(f'Comparing current ebuild version {version} with live version {top_hash}')
-    assert isinstance(use_vercmp, bool)
-    top_hash = sanitize_version(top_hash)
-    if ((use_vercmp and (vercmp(top_hash, version, silent=0) or 0) > 0) or top_hash != version):
+    if compare_versions(top_hash, version):
+        top_hash = sanitize_version(top_hash)
         if auto_update and cp not in settings.no_auto_update:
             ebuild = find_highest_match_ebuild_path(cp, search_dir)
             with open(ebuild) as f:

--- a/livecheck/utils/portage.py
+++ b/livecheck/utils/portage.py
@@ -3,20 +3,14 @@ from functools import cmp_to_key, lru_cache
 from pathlib import Path
 import logging
 import os
+import re
 
 from portage.versions import catpkgsplit, vercmp
 import portage
 
-__all__ = (
-    'P',
-    'catpkg_catpkgsplit',
-    'find_highest_match_ebuild_path',
-    'get_first_src_uri',
-    'get_highest_matches',
-    'get_highest_matches2',
-    'sort_by_v',
-    'get_repository_root_if_inside',
-)
+__all__ = ('P', 'catpkg_catpkgsplit', 'find_highest_match_ebuild_path', 'get_first_src_uri',
+           'get_highest_matches', 'get_highest_matches2', 'sort_by_v',
+           'get_repository_root_if_inside', 'compare_versions', 'sanitize_version')
 
 P = portage.db[portage.root]['porttree'].dbapi
 logger = logging.getLogger(__name__)
@@ -154,3 +148,66 @@ def get_repository_root_if_inside(directory: str) -> tuple[str, str]:
 
     # Return the most specific repository root, if found
     return selected_repo_root, selected_repo_name
+
+
+def is_hash(str: str) -> bool:
+    pattern = {
+        'MD5': r'[0-9a-f]{32}',
+        'SHA1': r'[0-9a-f]{40}',
+        'SHA256': r'[0-9a-f]{64}',
+        'SHA512': r'[0-9a-f]{128}',
+    }
+    for _, value in pattern.items():
+        if re.match(value, str):
+            return True
+    return False
+
+
+def is_version_development(version: str) -> bool:
+    if re.search(r'(alpha|beta|pre|dev|rc)', version, re.IGNORECASE):
+        return True
+    return False
+
+
+# Sanitize version to Gentoo Ebuild format
+# info: https://dev.gentoo.org/~gokturk/devmanual/pr65/ebuild-writing/file-format/index.html
+def sanitize_version(version: str) -> str:
+    if not version:
+        return '0'
+
+    # Force convert version to string to fix version like 1.8
+    version = str(version)
+
+    if is_hash(version):
+        return version
+
+    # remove initial "2-" found in dev-libs/libpcre2, net-analyzer/barnyard2, etc..
+    if version.startswith('2-'):
+        version = version[2:]
+
+    version = re.sub(r'(\d)_(\d)', r'\1.\2', version)
+    pattern = r"(\d+(\.\d+)*[a-z]?(_(alpha|beta|pre|rc|p)\d*)*(-r\d+)?)"
+
+    match = re.search(pattern, version, re.IGNORECASE)
+
+    if match:
+        if match.group(1) != version:
+            logger.debug(f'Version {version} sanitized to {match.group(1)}')
+        return match.group(1)
+    else:
+        return version
+
+
+def compare_versions(old: str, new: str) -> int | None:
+    if is_hash(old) and is_hash(new):
+        if old != new:
+            return 1
+        else:
+            return 0
+
+    # check if is a beta, alpa, pre or rc version and not accept this version
+    if is_version_development(new):
+        logger.debug(f'Not permitted development version {new}')
+        return 0
+
+    return vercmp(sanitize_version(new), sanitize_version(old), silent=0)

--- a/livecheck/utils/portage.py
+++ b/livecheck/utils/portage.py
@@ -198,16 +198,13 @@ def sanitize_version(version: str) -> str:
         return version
 
 
-def compare_versions(old: str, new: str) -> int | None:
+def compare_versions(old: str, new: str) -> bool:
     if is_hash(old) and is_hash(new):
-        if old != new:
-            return 1
-        else:
-            return 0
+        return old != new
 
     # check if is a beta, alpa, pre or rc version and not accept this version
     if is_version_development(new):
         logger.debug(f'Not permitted development version {new}')
-        return 0
+        return False
 
-    return vercmp(sanitize_version(new), sanitize_version(old), silent=0)
+    return vercmp(sanitize_version(new), sanitize_version(old), silent=0) == -1


### PR DESCRIPTION
* Update version sanitization
* Compare between hashes
* Simplifies version comparison

I have tried different ebuilds that use hash and everything seems to work
If everything is ok, the user_vercmp code could be eliminated, which would no longer be necessary