### PR TITLE
Show progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Options:
   -a, --auto-update            Rename and modify ebuilds.
   -d, --debug                  Enable debug logging.
   -e, --exclude TEXT           Exclude package(s) from updates.
-  -p, --process                Show the ebuild process
+  -p, --progress               Enable progress logging.
   -W, --working-dir DIRECTORY  Working directory. Should be a port tree root.
   --help                       Show this message and exit.
 ```

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Options:
   -a, --auto-update            Rename and modify ebuilds.
   -d, --debug                  Enable debug logging.
   -e, --exclude TEXT           Exclude package(s) from updates.
+  -p, --process                Show the ebuild process
   -W, --working-dir DIRECTORY  Working directory. Should be a port tree root.
   --help                       Show this message and exit.
 ```

--- a/livecheck/main.py
+++ b/livecheck/main.py
@@ -74,7 +74,7 @@ def sanitize_version(version: str) -> str:
 
     if match:
         if match.group(1) != version:
-            logger.debug(f'Version {version} sanitized to {match.group(1)}')
+            logger.warning(f'Version {version} sanitized to {match.group(1)}')
         return match.group(1)
     else:
         return version

--- a/livecheck/main.py
+++ b/livecheck/main.py
@@ -357,7 +357,7 @@ def do_main(*, auto_update: bool, cat: str, ebuild_version: str, parsed_uri: Par
         top_hash = (sorted(results, key=cmp_to_key(special_vercmp), reverse=True)
                     if use_vercmp else results)[0]
     except IndexError:
-        logger.debug(f'Attempted to fix top_hash version but it failed in {cp}')
+        logger.warning(f'Attempted to fix top_hash version but it failed in {cp}')
         return
     # Convert top_hash to string always to fix version like 1.8
     top_hash = str(top_hash)

--- a/livecheck/main.py
+++ b/livecheck/main.py
@@ -74,7 +74,7 @@ def sanitize_version(version: str) -> str:
 
     if match:
         if match.group(1) != version:
-            logger.warning(f'Version {version} sanitized to {match.group(1)}')
+            logger.debug(f'Version {version} sanitized to {match.group(1)}')
         return match.group(1)
     else:
         return version
@@ -119,7 +119,10 @@ def get_props(search_dir: str,
               repo_root: str,
               settings: LivecheckSettings,
               names: Sequence[str] | None = None,
-              exclude: Sequence[str] | None = None) -> Iterator[PropTuple]:
+              exclude: Sequence[str] | None = None,
+              *,
+              progress: bool = False,
+              debug: bool = False) -> Iterator[PropTuple]:
     exclude = exclude or []
     try:
         matches = unique_justseen(sorted(set(
@@ -134,7 +137,7 @@ def get_props(search_dir: str,
         logger.error(f"Unexpected error: {e}")
         return None
     matches_list = list(matches)
-    logger.debug(f'Found {len(matches_list)} ebuilds')
+    logger.info(f'Found {len(matches_list)} ebuilds')
     if not matches_list:
         logger.error('No matches!')
         raise click.Abort
@@ -153,6 +156,8 @@ def get_props(search_dir: str,
         if not src_uri or re.search(r'9999', ebuild_version):
             logger.debug(f'Ignoring {catpkg}')
             continue
+        if debug or progress:
+            logger.info(f'Processing {catpkg} version {ebuild_version}')
         if catpkg in settings.custom_livechecks:
             url, regex, use_vercmp, version = settings.custom_livechecks[catpkg]
             yield (cat, pkg, version or ebuild_version, version
@@ -352,7 +357,7 @@ def do_main(*, auto_update: bool, cat: str, ebuild_version: str, parsed_uri: Par
         top_hash = (sorted(results, key=cmp_to_key(special_vercmp), reverse=True)
                     if use_vercmp else results)[0]
     except IndexError:
-        logger.warning(f'Attempted to fix top_hash version but it failed in {cp}')
+        logger.debug(f'Attempted to fix top_hash version but it failed in {cp}')
         return
     # Convert top_hash to string always to fix version like 1.8
     top_hash = str(top_hash)
@@ -447,6 +452,7 @@ def do_main(*, auto_update: bool, cat: str, ebuild_version: str, parsed_uri: Par
 @click.option('-a', '--auto-update', is_flag=True, help='Rename and modify ebuilds.')
 @click.option('-d', '--debug', is_flag=True, help='Enable debug logging.')
 @click.option('-e', '--exclude', multiple=True, help='Exclude package(s) from updates.')
+@click.option('-p', '--progress', is_flag=True, help='Enable progress logging.')
 @click.option('-W',
               '--working-dir',
               default='.',
@@ -456,6 +462,7 @@ def do_main(*, auto_update: bool, cat: str, ebuild_version: str, parsed_uri: Par
 def main(
     auto_update: bool = False,
     debug: bool = False,
+    progress: bool = False,
     exclude: tuple[str] | None = None,
     package_names: tuple[str] | list[str] | None = None,
     working_dir: str | None = '.',
@@ -465,7 +472,14 @@ def main(
     if debug:
         logging.basicConfig(level=logging.DEBUG)
     else:
-        logger.configure(handlers=[{"sink": sys.stderr, "level": "INFO"}])
+        logger.configure(handlers=[{
+            "sink":
+                sys.stderr,
+            "level":
+                "INFO",
+            "format":
+                "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | <level>{level: <8}</level> | <level>{message}</level>"
+        }])
     if exclude:
         logger.debug(f'Excluding {", ".join(exclude)}')
     search_dir = working_dir or '.'
@@ -476,12 +490,17 @@ def main(
     if not repo_root:
         logger.error('Not inside a repository configured in repos.conf')
         raise click.Abort
-    logger.debug(f'search_dir={search_dir} repo_root={repo_root} repo_name={repo_name}')
+    logger.info(f'search_dir={search_dir} repo_root={repo_root} repo_name={repo_name}')
     session = requests.Session()
     settings = gather_settings(search_dir)
     package_names = sorted(package_names or [])
-    for cat, pkg, ebuild_version, version, url, regex, _use_vercmp in get_props(
-            search_dir, repo_root, settings, package_names, exclude):
+    for cat, pkg, ebuild_version, version, url, regex, _use_vercmp in get_props(search_dir,
+                                                                                repo_root,
+                                                                                settings,
+                                                                                package_names,
+                                                                                exclude,
+                                                                                progress=progress,
+                                                                                debug=debug):
         logger.debug(f'Fetching {url}')
         headers = {}
         parsed_uri = urlparse(url)
@@ -514,7 +533,7 @@ def main(
                     ebuild_version=ebuild_version,
                     version=version)
         except (requests.exceptions.HTTPError, requests.exceptions.SSLError) as e:
-            logger.warning(f'Caught error while checking {cat}/{pkg}: {e}')
+            logger.debug(f'Caught error while checking {cat}/{pkg}: {e}')
         except Exception:
             print(f'Exception while checking {cat}/{pkg}', file=sys.stderr)
             raise


### PR DESCRIPTION
Convert warnings to debug so as not to show unnecessary information, and thus show a cleaner report