### PR TITLE
improves ebuild search

### DIFF
--- a/livecheck/main.py
+++ b/livecheck/main.py
@@ -48,16 +48,13 @@ from .utils import (
     is_sha,
     make_github_grit_commit_re,
     make_github_grit_title_re,
-    unique_justseen,
 )
 from .utils.portage import (
     P,
     catpkg_catpkgsplit,
-    find_highest_match_ebuild_path,
     get_first_src_uri,
     get_highest_matches,
     get_highest_matches2,
-    sort_by_v,
     get_repository_root_if_inside,
     sanitize_version,
     compare_versions,
@@ -111,18 +108,15 @@ def get_props(search_dir: str,
               debug: bool = False) -> Iterator[PropTuple]:
     exclude = exclude or []
     try:
-        matches = unique_justseen(sorted(set(
+        matches_list = sorted(
             get_highest_matches(search_dir, repo_root
-                                ) if not names else get_highest_matches2(names, search_dir)),
-                                         key=cmp_to_key(sort_by_v)),
-                                  key=lambda a: catpkg_catpkgsplit(a)[0])
+                                ) if not names else get_highest_matches2(names, repo_root))
     except InvalidAtom as e:
         logger.error(f"Invalid Atom: {e}")
         return None
     except Exception as e:
         logger.error(f"Unexpected error: {e}")
         return None
-    matches_list = list(matches)
     logger.info(f'Found {len(matches_list)} ebuilds')
     if not matches_list:
         logger.error('No matches!')
@@ -132,14 +126,14 @@ def get_props(search_dir: str,
         if catpkg in exclude or pkg in exclude:
             logger.debug(f'Ignoring {catpkg}')
             continue
-        src_uri = get_first_src_uri(match)
+        src_uri = get_first_src_uri(match, repo_root)
         parsed_uri = urlparse(src_uri)
         if cat.startswith('acct-') or catpkg in settings.ignored_packages:
             logger.debug(f'Ignoring {catpkg}')
             continue
-        # Exclude packages with no SRC_URI or with version contain 9999
+        # Exclude packages with no SRC_URI
         # live ebuilds o virtual packages
-        if not src_uri or re.search(r'9999', ebuild_version):
+        if not src_uri:
             logger.debug(f'Ignoring {catpkg}')
             continue
         if debug or progress:
@@ -357,8 +351,8 @@ def do_main(*, auto_update: bool, cat: str, ebuild_version: str, parsed_uri: Par
     logger.debug(f'Comparing current ebuild version {version} with live version {top_hash}')
     if compare_versions(top_hash, version):
         top_hash = sanitize_version(top_hash)
+        ebuild = os.path.join(search_dir, cp, f'{pkg}-{ebuild_version}.ebuild')
         if auto_update and cp not in settings.no_auto_update:
-            ebuild = find_highest_match_ebuild_path(cp, search_dir)
             with open(ebuild) as f:
                 old_content = f.read()
             content = old_content.replace(version, top_hash)
@@ -415,7 +409,6 @@ def do_main(*, auto_update: bool, cat: str, ebuild_version: str, parsed_uri: Par
             sha_str = ''
             new_sha = ''
             if update_sha_too_source:
-                ebuild = find_highest_match_ebuild_path(cp, search_dir)
                 old_sha = get_old_sha(ebuild)
                 sha_str = f' ({old_sha}) '
                 logger.debug(f'Fetching {update_sha_too_source}')

--- a/livecheck/utils/portage.py
+++ b/livecheck/utils/portage.py
@@ -1,5 +1,4 @@
-from ast import Dict
-from collections.abc import Iterator, Sequence
+from collections.abc import Sequence
 from functools import cmp_to_key, lru_cache
 from pathlib import Path
 import logging


### PR DESCRIPTION
Search for the packages without 9999 to choose the best ones directly in the search and thus we save having to search for them with the find_highest_match_ebuild_path function and now only show the latest versions
Support for revisions -rXXX