### PR TITLE
Massive updates

### DIFF
--- a/.vscode/dictionary.txt
+++ b/.vscode/dictionary.txt
@@ -1,4 +1,6 @@
+analyzer
 archiver
+arcname
 asmjit
 atrac
 automodule
@@ -12,10 +14,13 @@ commitizen
 cookiecutter
 cython
 dbapi
+distdir
+distfiles
 dlmalloc
 docparams
 doctrees
 docutils
+doebuild
 dotize
 dynarmic
 ebuilds
@@ -28,12 +33,14 @@ esbenp
 esbonio
 eselect
 excinfo
+fetchlist
 findname
 freedesktop
 genconfig
 genindex
 getabsfile
 glabels
+gomodule
 hidapi
 hostnames
 htmlcov
@@ -53,6 +60,7 @@ levelno
 libchdr
 libfat
 libimobiledevice
+libpcre2
 libshared
 linters
 livecheck
@@ -76,6 +84,8 @@ pipx
 pkgdev
 pkgs
 pluggy
+portdb
+portdir
 porttree
 prerelease
 psvpfstools
@@ -118,6 +128,7 @@ vercmp
 virtualenv
 wiimm
 wiimms
+workdir
 xbyak
 xemu
 xmatch

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ This package can do automated lookups based on commonly used hosts. Currently:
 - GitHub releases
 - JetBrains products
 - PyPI
+- Sourceforge
+- PECL
+- RubyGems
+- Perl CPAN
 
 This works as long as the version system is usable with Portage's version
 comparison function. For anything else, see [Package configuration](#package-configuration).
@@ -67,6 +71,11 @@ For packages that will not work with currently heuristic checking, a configurati
 - `type` - `none`, `regex`, or `checksum`.
 - `url` - URL of the document to run regular expressions against.
 - `use_vercmp` - boolean - if `vercmp` from Portage should be used. Default: `true`.
+- `gomodule_packages` - boolean - Download go vendor modules
+- `gomodule_path` - path - Where is 'go.mod' located (need gomodule_packages)
+- `jetbrains_packages` - boolean - Update internal ID.
+- `nodejs_packages` - boolean - Download nodejs node_modules
+- `nodejs_path` - path - Where is 'package.json' located (need nodejs_packages)
 
 ## Development use
 

--- a/livecheck/settings.py
+++ b/livecheck/settings.py
@@ -2,7 +2,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 import json
-import logging
+from urllib.parse import urlparse
 
 import livecheck.special.handlers as sc
 
@@ -10,7 +10,7 @@ from . import utils
 
 __all__ = ('LivecheckSettings', 'gather_settings')
 
-logger = logging.getLogger(__name__)
+from loguru import logger
 
 
 @dataclass
@@ -35,6 +35,10 @@ class LivecheckSettings:
     yarn_packages: dict[str, set[str]]
     jetbrains_packages: dict[str, bool]
     keep_old: dict[str, bool]
+    gomodule_packages: dict[str, bool]
+    gomodule_path: dict[str, str]
+    nodejs_packages: dict[str, bool]
+    nodejs_path: dict[str, str]
 
 
 class UnknownTransformationFunction(NameError):
@@ -57,30 +61,44 @@ def gather_settings(search_dir: str) -> LivecheckSettings:
     yarn_packages: dict[str, set[str]] = {}
     jetbrains_packages: dict[str, bool] = {}
     keep_old: dict[str, bool] = {}
+    gomodule_packages: dict[str, bool] = {}
+    gomodule_path: dict[str, str] = {}
+    nodejs_packages: dict[str, bool] = {}
+    nodejs_path: dict[str, str] = {}
     for path in Path(search_dir).glob('**/livecheck.json'):
-        logger.debug('Opening %s', path)
+        logger.debug(f"Opening {path}")
         with path.open() as f:
             dn = path.parent
             catpkg = f'{dn.parent.name}/{dn.name}'
             try:
                 settings_parsed = json.load(f)
             except json.JSONDecodeError as e:
-                logger.error('Error parsing file %s: %s', path, e)
+                logger.error(f"Error parsing file {path}: {e}")
                 continue
-            if settings_parsed.get('type') == 'none':
-                ignored_packages.add(catpkg)
-            elif settings_parsed.get('type') == 'regex':
-                custom_livechecks[catpkg] = (settings_parsed['url'], settings_parsed['regex'],
-                                             settings_parsed.get('use_vercmp', True),
-                                             settings_parsed.get('version', None))
-            elif settings_parsed.get('type') == 'checksum':
-                checksum_livechecks.add(catpkg)
+            if settings_parsed.get('type') != None:
+                if settings_parsed.get('type').lower() == 'none':
+                    ignored_packages.add(catpkg)
+                elif settings_parsed.get('type').lower() == 'regex':
+                    custom_livechecks[catpkg] = (settings_parsed['url'], settings_parsed['regex'],
+                                                 settings_parsed.get('use_vercmp', True),
+                                                 settings_parsed.get('version', None))
+                elif settings_parsed.get('type').lower() == 'checksum':
+                    checksum_livechecks.add(catpkg)
+                else:
+                    logger.error(
+                        f'Unknown "type" in {path}, only "none", "regex", and "checksum" are supported.'
+                    )
             if settings_parsed.get('branch'):
+                check_instance(settings_parsed['branch'], 'branch', 'string', path)
                 branches[catpkg] = settings_parsed['branch']
             if 'no_auto_update' in settings_parsed:
+                check_instance(settings_parsed['no_auto_update'], 'no_auto_update', 'bool', path,
+                               True)
                 no_auto_update.add(catpkg)
             if settings_parsed.get('transformation_function', None):
                 tfs = settings_parsed['transformation_function']
+                check_instance(settings_parsed['transformation_function'],
+                               'transformation_function', 'string', path)
                 try:
                     tf: Callable[[str], str] = getattr(sc, tfs)
                 except AttributeError:
@@ -90,22 +108,78 @@ def gather_settings(search_dir: str) -> LivecheckSettings:
                         raise UnknownTransformationFunction(tfs) from e
                 transformations[catpkg] = tf
             if settings_parsed.get('sha_source'):
+                check_instance(settings_parsed['sha_source'], 'sha_source', 'url', path)
                 sha_sources[catpkg] = settings_parsed['sha_source']
             if settings_parsed.get('yarn_base_package'):
+                check_instance(settings_parsed['yarn_base_package'], 'yarn_base_package', 'string',
+                               path)
                 yarn_base_packages[catpkg] = settings_parsed['yarn_base_package']
                 if settings_parsed.get('yarn_packages'):
+                    check_instance(settings_parsed['yarn_packages'], 'yarn_packages', 'list', path)
                     yarn_packages[catpkg] = set(settings_parsed['yarn_packages'])
             if settings_parsed.get('go_sum_uri'):
+                check_instance(settings_parsed['go_sum_uri'], 'go_sum_uri', 'url', path)
                 golang_packages[catpkg] = settings_parsed['go_sum_uri']
             if settings_parsed.get('dotnet_project'):
+                check_instance(settings_parsed['dotnet_project'], 'dotnet_project', 'string', path)
                 dotnet_projects[catpkg] = settings_parsed['dotnet_project']
             if 'semver' in settings_parsed:
+                check_instance(settings_parsed['semver'], 'semver', 'bool', path)
                 semver[catpkg] = settings_parsed['semver']
             if 'jetbrains' in settings_parsed:
+                check_instance(settings_parsed['jetbrains'], 'jetbrains', 'bool', path)
                 jetbrains_packages[catpkg] = settings_parsed['jetbrains']
             if 'keep_old' in settings_parsed:
+                check_instance(settings_parsed['keep_old'], 'keep_old', 'bool', path)
                 keep_old[catpkg] = settings_parsed['keep_old']
+            if 'gomodule' in settings_parsed:
+                check_instance(settings_parsed['gomodule'], 'gomodule', 'bool', path)
+                gomodule_packages[catpkg] = settings_parsed['gomodule']
+                gomodule_path[catpkg] = ""
+                if settings_parsed.get('gomodule_path'):
+                    check_instance(settings_parsed['gomodule_path'], 'gomodule_path', 'string',
+                                   path)
+                    gomodule_path[catpkg] = settings_parsed['gomodule_path']
+            if 'nodejs' in settings_parsed:
+                check_instance(settings_parsed['nodejs'], 'nodejs', 'bool', path)
+                nodejs_packages[catpkg] = settings_parsed['nodejs']
+                nodejs_path[catpkg] = ""
+                if settings_parsed.get('nodejs_path'):
+                    check_instance(settings_parsed['nodejs_path'], 'nodejs_path', 'string', path)
+                    nodejs_path[catpkg] = settings_parsed['nodejs_path']
+
     return LivecheckSettings(branches, checksum_livechecks, custom_livechecks, dotnet_projects,
                              golang_packages, ignored_packages, no_auto_update, semver, sha_sources,
                              transformations, yarn_base_packages, yarn_packages, jetbrains_packages,
-                             keep_old)
+                             keep_old, gomodule_packages, gomodule_path, nodejs_packages,
+                             nodejs_path)
+
+
+def check_instance(value: int | str | bool | list[str] | None,
+                   key: str,
+                   type: str,
+                   path: str | object,
+                   specific_value: bool | int | str | None = None) -> None:
+    is_type = False
+    if type == 'bool':
+        is_type = isinstance(value, bool)
+    elif type == 'int':
+        is_type = isinstance(value, int)
+    elif type == 'string':
+        is_type = isinstance(value, str)
+    elif type == 'none':
+        is_type = value == None
+    elif type == 'list':
+        is_type = isinstance(value, list)
+    elif type == 'url':
+        if isinstance(value, str):
+            parsed_url = urlparse(value)
+            is_type = all([parsed_url.scheme, parsed_url.netloc])
+
+    if not is_type:
+        logger.error(f"Value \"{value}\" in key \"{key}\" is not of type \"{type}\" in file {path}")
+
+    if specific_value is not None and value != specific_value:
+        logger.error(
+            f"Value \"{value}\" in key \"{key}\" is not equal to \"{specific_value}\" in file {path}"
+        )

--- a/livecheck/special/nodejs.py
+++ b/livecheck/special/nodejs.py
@@ -1,0 +1,29 @@
+import subprocess as sp
+from .utils import remove_url_ebuild, search_ebuild, build_compress
+
+from loguru import logger
+
+__all__ = ("update_nodejs_ebuild", "remove_nodejs_url")
+
+
+def remove_nodejs_url(ebuild_content: str) -> str:
+    return remove_url_ebuild(ebuild_content, '-node_modules.tar.xz')
+
+
+def update_nodejs_ebuild(ebuild: str, path: str | None) -> None:
+    package_path, temp_dir = search_ebuild(ebuild, 'package.json', path)
+    if package_path == "":
+        return
+
+    try:
+        sp.run([
+            'npm', 'install', '--audit false', '--color false', '--progress false',
+            '--ignore-scripts'
+        ],
+               cwd=package_path,
+               check=True)
+    except sp.CalledProcessError as e:
+        logger.error(f"Error running 'npm install': {e}")
+        return
+
+    build_compress(ebuild, temp_dir, package_path, 'node_modules', "-node_modules.tar.xz")

--- a/livecheck/special/utils.py
+++ b/livecheck/special/utils.py
@@ -1,9 +1,100 @@
 from pathlib import Path
+import logging
 
 from xdg.BaseDirectory import save_cache_path
 
-__all__ = ("get_project_path",)
+import os
+import tarfile
+import portage
+from ..utils.portage import unpack_ebuild, get_distdir
+
+__all__ = ("get_project_path", "remove_url_ebuild", "search_ebuild", "build_compress")
+
+logger = logging.getLogger(__name__)
 
 
 def get_project_path(package_name: str) -> Path:
     return Path(save_cache_path(f"livecheck/{package_name}"))
+
+
+def remove_url_ebuild(ebuild: str, remove: str) -> str:
+    lines = ebuild.split('\n')
+    filtered_lines = []
+    for _, line in enumerate(lines):
+        original_line = line
+        stripped_line = line.strip()
+        if not stripped_line or stripped_line.startswith('#'):
+            filtered_lines.append(original_line)
+            continue
+        if remove in stripped_line:
+            url = stripped_line.strip(' "\'')
+            if url.endswith(remove):
+                if stripped_line.endswith(('"', "'")):
+                    filtered_lines.append(stripped_line[-1])
+                continue
+        filtered_lines.append(original_line)
+    return '\n'.join(filtered_lines)
+
+
+def search_ebuild(ebuild: str, archive: str, path: str) -> tuple[str, str]:
+    temp_dir = unpack_ebuild(ebuild)
+    if temp_dir == "":
+        logger.warning("Error unpacking the ebuild.")
+        return "", ""
+
+    if path:
+        # Search first directory in temp_dir
+        for root, _, files in os.walk(temp_dir):
+            # check if relative path is in the root
+            if path in root:
+                return root, temp_dir
+    else:
+        for root, _, files in os.walk(temp_dir):
+            if archive in files:
+                return root, temp_dir
+
+    logger.error("Error searching the \"{archive}\" inside package.")
+
+    return "", ""
+
+
+def build_compress(ebuild: str, temp_dir: str, base_dir: str, directory: str,
+                   extension: str) -> bool:
+
+    vendor_dir = os.path.join(base_dir, directory)
+    if not os.path.exists(vendor_dir):
+        logger.warning("The directory vendor was not created.")
+        return False
+
+    ebuild_filename = os.path.basename(ebuild)
+    cpv = ebuild_filename.replace(".ebuild", "")
+    category = os.path.basename(os.path.dirname(os.path.dirname(ebuild)))
+
+    fetchlist = portage.portdb.getFetchMap(f"{category}/{cpv}")
+    filename, _ = next(iter(fetchlist.items()))
+
+    if filename.endswith('.tar.gz'):
+        archive_ext = '.tar.gz'
+    elif filename.endswith('.tgz'):
+        archive_ext = '.tgz'
+    elif filename.endswith('.tar.xz'):
+        archive_ext = '.xz'
+    elif filename.endswith('.zip'):
+        archive_ext = '.zip'
+    else:
+        logger.warning("Invalid extension.")
+        return False
+
+    base_name = filename[:-len(archive_ext)]
+    vendor_archive_name = f"{base_name}{extension}"
+    vendor_archive_path = os.path.join(get_distdir(), vendor_archive_name)
+
+    vendor_path = Path(base_dir).resolve()
+    base_path = Path(temp_dir).resolve()
+
+    relative_path = os.path.join(vendor_path.relative_to(base_path), directory)
+
+    with tarfile.open(vendor_archive_path, "w:xz") as tar:
+        tar.add(vendor_dir, arcname=str(relative_path))
+
+    return True

--- a/livecheck/utils/__init__.py
+++ b/livecheck/utils/__init__.py
@@ -69,8 +69,11 @@ def parse_npm_package_name(s: str) -> tuple[str, str | None, str | None]:
 
 @lru_cache
 def get_github_api_credentials() -> str:
-    with Path('~/.config/gh/hosts.yml').expanduser().open() as f:
-        data = yaml.safe_load(f)
+    try:
+        with Path('~/.config/gh/hosts.yml').expanduser().open() as f:
+            data = yaml.safe_load(f)
+    except FileNotFoundError:
+        return ''
     return cast(str, data['github.com']['oauth_token'])
 
 

--- a/livecheck/utils/portage.py
+++ b/livecheck/utils/portage.py
@@ -1,17 +1,19 @@
 from collections.abc import Sequence
 from functools import cmp_to_key, lru_cache
+from genericpath import isdir
 from pathlib import Path
 import logging
 import os
 import re
 from typing import List
 
-from portage.versions import catpkgsplit, vercmp, pkgcmp
+from portage.versions import catpkgsplit, vercmp
 import portage
 
 __all__ = ('P', 'catpkg_catpkgsplit', 'find_highest_match_ebuild_path', 'get_first_src_uri',
            'get_highest_matches', 'get_highest_matches2', 'sort_by_v',
-           'get_repository_root_if_inside', 'compare_versions', 'sanitize_version')
+           'get_repository_root_if_inside', 'compare_versions', 'sanitize_version', 'get_distdir',
+           'fetch_ebuild', 'unpack_ebuild')
 
 P = portage.db[portage.root]['porttree'].dbapi
 logger = logging.getLogger(__name__)
@@ -231,3 +233,43 @@ def compare_versions(old: str, new: str) -> bool:
         return False
 
     return vercmp(sanitize_version(new), sanitize_version(old), silent=0) == -1
+
+
+def get_distdir() -> str:
+    settings = portage.config(clone=portage.settings)
+    distdir = settings.get('DISTDIR')
+    if distdir:
+        return distdir
+
+    return '/var/cache/distfiles'
+
+
+def fetch_ebuild(ebuild_path: str) -> bool:
+    settings = portage.config(clone=portage.settings)
+
+    return portage.doebuild(ebuild_path, 'fetch', settings=settings, tree='porttree') == 0
+
+
+def digest_ebuild(ebuild_path: str) -> bool:
+    settings = portage.config(clone=portage.settings)
+
+    return portage.doebuild(ebuild_path, 'digest', settings=settings, tree='porttree') == 0
+
+
+def unpack_ebuild(ebuild_path: str) -> str:
+    settings = portage.config(clone=portage.settings)
+    #if not digest_ebuild(ebuild_path):
+    #    return ''
+
+    if portage.doebuild(ebuild_path, 'clean', settings=settings, tree='porttree') != 0:
+        return ''
+
+    if portage.doebuild(ebuild_path, 'unpack', settings=settings, tree='porttree') != 0:
+        return ''
+
+    workdir = settings["WORKDIR"]
+
+    if os.path.exists(workdir) and os.path.isdir(workdir):
+        return workdir
+
+    return ''

--- a/man/livecheck.1
+++ b/man/livecheck.1
@@ -27,9 +27,9 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "LIVECHECK" "1" "Dec 03, 2023" "0.0.1" "livecheck"
+.TH "PORTAGE-LIVECHECK" "1" "Dec 03, 2023" "0.0.1" "portage-livecheck"
 .SH NAME
-livecheck \- livecheck v0.0.1
+portage-livecheck \- portage-livecheck v0.0.1
 .SH COMMANDS
 .SS livecheck
 .INDENT 0.0
@@ -96,7 +96,7 @@ Utility functions.
 .SH SETTINGS
 .INDENT 0.0
 .TP
-.B class livecheck.settings.LivecheckSettings(branches: dict[str, str], checksum_livechecks: set[str], custom_livechecks: dict[str, tuple[str, str, bool, str]], dotnet_projects: dict[str, str], go_sum_uri: dict[str, str], ignored_packages: set[str], no_auto_update: set[str], semver: dict[str, bool], sha_sources: dict[str, str], transformations: collections.abc.Mapping[str, collections.abc.Callable[[str], str]], yarn_base_packages: dict[str, str], yarn_packages: dict[str, set[str]], jetbrains: set[bool], keep_old: dict[str, bool])
+.B class livecheck.settings.LivecheckSettings(branches: dict[str, str], checksum_livechecks: set[str], custom_livechecks: dict[str, tuple[str, str, bool, str]], dotnet_projects: dict[str, str], go_sum_uri: dict[str, str], ignored_packages: set[str], no_auto_update: set[str], semver: dict[str, bool], sha_sources: dict[str, str], transformations: collections.abc.Mapping[str, collections.abc.Callable[[str], str]], yarn_base_packages: dict[str, str], yarn_packages: dict[str, set[str]], jetbrains: dict[str, bool], keep_old: dict[str, bool], gomodule_packages: dict[str, bool], gomodule_path: dict[str, str], nodejs_packages: dict[str, bool], nodejs_path: dict[str, str])
 .INDENT 7.0
 .TP
 .B dotnet_projects: dict[str, str]


### PR DESCRIPTION
regenerate the pull request again #240

* Add 2 new modules to update the ebuilds
* Along the way I have improved the logic of uploading to git
* The digest is now generated automatically
* I have changed it so that there are multiple updates.
* There are ebuilds that have both gomod and nodejs to process
* I have added parameter control in the json file
* Solve an error when the hosts.yml file does not exist and without a manifest file for livechecks
* Add more types of variables to obtain the old sha
* Remove variable prefixes in do_main, no longer used
* If the ebuild matches, use a new revision -r(+1)
* Unify the code to show the new ebuilds
* Moves the process of obtaining the regex within do_main, there may be code that does not use regex (jetbrains, pecl, sf, etc.) and thus eliminates the need to download the url
* Fix previous issues with packages

<pre>
$ python -m livecheck -W /usr/portage/local/tatsh-overlay/ -p -d -a vapoursynth-fsrcnn-ncnn-vulkan
2024-11-25 19:22:04.819 | INFO     | livecheck.main:main:552 - search_dir=/usr/portage/local/tatsh-overlay repo_root=/usr/portage/local/tatsh-overlay repo_name=tatsh-overlay
2024-11-25 19:22:04.840 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/dev-util/vscode-vsce/livecheck.json
2024-11-25 19:22:04.841 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/dev-util/react-native-decompiler/livecheck.json
2024-11-25 19:22:04.842 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/dev-util/vcpkg-tool/livecheck.json
2024-11-25 19:22:04.843 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/dev-util/spirv-cross/livecheck.json
2024-11-25 19:22:04.844 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/dev-util/wakatime-cli/livecheck.json
2024-11-25 19:22:04.845 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/dev-util/ida-free/livecheck.json
2024-11-25 19:22:04.847 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/dev-util/create-react-app/livecheck.json
2024-11-25 19:22:04.849 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/dev-util/prettier/livecheck.json
2024-11-25 19:22:04.849 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/dev-util/yo/livecheck.json
2024-11-25 19:22:04.857 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/media-gfx/flash-player-projector/livecheck.json
2024-11-25 19:22:04.857 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/media-gfx/pngdefry/livecheck.json
2024-11-25 19:22:04.860 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/games-misc/render96ex/livecheck.json
2024-11-25 19:22:04.862 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/dev-tcltk/tclkit/livecheck.json
2024-11-25 19:22:04.863 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/dev-tcltk/sdx/livecheck.json
2024-11-25 19:22:04.868 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/dev-qt/qtquick3d/livecheck.json
2024-11-25 19:22:04.870 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/mail-mta/sendgmail/livecheck.json
2024-11-25 19:22:04.871 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/net-misc/muffet/livecheck.json
2024-11-25 19:22:04.872 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/net-misc/wayback-machine-downloader/livecheck.json
2024-11-25 19:22:04.873 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/dev-build/node-gyp/livecheck.json
2024-11-25 19:22:04.874 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/net-im/ripcord/livecheck.json
2024-11-25 19:22:04.878 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/sys-auth/fprintd/livecheck.json
2024-11-25 19:22:04.884 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/sys-devel/llvm/livecheck.json
2024-11-25 19:22:04.894 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/games-action/revc/livecheck.json
2024-11-25 19:22:04.895 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/games-action/relcs/livecheck.json
2024-11-25 19:22:04.896 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/games-action/re3/livecheck.json
2024-11-25 19:22:04.900 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/net-proxy/charles/livecheck.json
2024-11-25 19:22:04.903 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/net-vpn/f5vpn/livecheck.json
2024-11-25 19:22:04.906 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/sys-kernel/msi-ec/livecheck.json
2024-11-25 19:22:04.909 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/dev-libs/wolfssl/livecheck.json
2024-11-25 19:22:04.918 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/media-fonts/noto/livecheck.json
2024-11-25 19:22:04.919 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/app-office/glabels/livecheck.json
2024-11-25 19:22:04.927 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/dev-python/gooey/livecheck.json
2024-11-25 19:22:04.939 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/dev-python/llvmlite/livecheck.json
2024-11-25 19:22:04.950 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/dev-vcs/gickup/livecheck.json
2024-11-25 19:22:04.951 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/dev-vcs/blackbox/livecheck.json
2024-11-25 19:22:04.954 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/games-util/wiimms-szs-tools/livecheck.json
2024-11-25 19:22:04.956 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/games-util/wiimms-iso-tools/livecheck.json
2024-11-25 19:22:04.957 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/games-util/switch-library-manager/livecheck.json
2024-11-25 19:22:04.965 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/mpv-plugin/mpv-lrc/livecheck.json
2024-11-25 19:22:04.973 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/app-cdr/qpxtool/livecheck.json
2024-11-25 19:22:04.974 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/app-cdr/cdi2nero/livecheck.json
2024-11-25 19:22:04.974 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/app-cdr/cdirip/livecheck.json
2024-11-25 19:22:04.977 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/media-sound/sony-headphones-client/livecheck.json
2024-11-25 19:22:04.978 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/media-sound/yamaha-xg-soundfont/livecheck.json
2024-11-25 19:22:04.980 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/app-misc/pyrescene/livecheck.json
2024-11-25 19:22:04.980 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/app-misc/zwave-js-server/livecheck.json
2024-11-25 19:22:04.981 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/app-misc/fx/livecheck.json
2024-11-25 19:22:04.986 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/x11-misc/mimeo/livecheck.json
2024-11-25 19:22:04.988 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/games-arcade/stepmania/livecheck.json
2024-11-25 19:22:04.989 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/games-arcade/outfox/livecheck.json
2024-11-25 19:22:04.990 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/games-arcade/outfox-serenity/livecheck.json
2024-11-25 19:22:04.991 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/games-arcade/clone-hero/livecheck.json
2024-11-25 19:22:04.994 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/app-arch/unalz/livecheck.json
2024-11-25 19:22:04.996 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/app-arch/asar/livecheck.json
2024-11-25 19:22:05.000 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/dev-db/dbeaver-bin/livecheck.json
2024-11-25 19:22:05.002 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/sys-apps/tinkup/livecheck.json
2024-11-25 19:22:05.003 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/sys-apps/seatools/livecheck.json
2024-11-25 19:22:05.011 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/media-video/ytarchive/livecheck.json
2024-11-25 19:22:05.014 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/media-video/magewell-pro-capture/livecheck.json
2024-11-25 19:22:05.015 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/media-video/video2x/livecheck.json
2024-11-25 19:22:05.018 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/media-video/videoduplicatefinder/livecheck.json
2024-11-25 19:22:05.018 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/media-video/scenechange/livecheck.json
2024-11-25 19:22:05.021 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/media-video/ffms2/livecheck.json
2024-11-25 19:22:05.023 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/media-video/vhs-decode/livecheck.json
2024-11-25 19:22:05.033 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/net-mail/gmailctl/livecheck.json
2024-11-25 19:22:05.035 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/www-apps/stash/livecheck.json
2024-11-25 19:22:05.036 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/www-apps/wakapi/livecheck.json
2024-11-25 19:22:05.038 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/games-emulation/sudachi/livecheck.json
2024-11-25 19:22:05.039 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/games-emulation/cemu/livecheck.json
2024-11-25 19:22:05.041 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/games-emulation/mupen64plus-input-raphnetraw/livecheck.json
2024-11-25 19:22:05.042 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/games-emulation/xemu/livecheck.json
2024-11-25 19:22:05.043 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/games-emulation/vita3k/livecheck.json
2024-11-25 19:22:05.044 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/games-emulation/bsnes-hd/livecheck.json
2024-11-25 19:22:05.045 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/games-emulation/yuzu/livecheck.json
2024-11-25 19:22:05.046 | DEBUG    | livecheck.settings:gather_settings:69 - Opening /usr/portage/local/tatsh-overlay/games-emulation/play/livecheck.json
DEBUG:asyncio:Using selector: EpollSelector
2024-11-25 19:22:05.124 | INFO     | livecheck.main:get_props:109 - Found 1 ebuilds
2024-11-25 19:22:05.124 | INFO     | livecheck.main:get_props:129 - Processing media-video/vapoursynth-fsrcnn-ncnn-vulkan version 20241112
2024-11-25 19:22:05.124 | DEBUG    | livecheck.main:get_props:165 - Parsed path: /Sg4Dylan/vapoursynth-fsrcnn-ncnn-vulkan/archive/c9dad37dad64346afdff925fb409e6c6005b719a.tar.gz
2024-11-25 19:22:05.124 | DEBUG    | livecheck.main:do_main:324 - Fetching https://github.com/Sg4Dylan/vapoursynth-fsrcnn-ncnn-vulkan/commits/master.atom
2024-11-25 19:22:05.124 | DEBUG    | livecheck.main:do_main:332 - Adding Accept header for XML
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): github.com:443
DEBUG:urllib3.connectionpool:https://github.com:443 "GET /Sg4Dylan/vapoursynth-fsrcnn-ncnn-vulkan/commits/master.atom HTTP/11" 200 4191
2024-11-25 19:22:05.508 | DEBUG    | livecheck.main:do_main:344 - Using RE: "<id>tag:github.com,2008:Grit::Commit/([0-9a-f]{40})[0-9a-f]*</id>"
2024-11-25 19:22:05.508 | DEBUG    | livecheck.main:do_main:356 - Result count: 5
2024-11-25 19:22:05.508 | DEBUG    | livecheck.main:do_main:360 - re.findall() -> "0a721959116f6f86dbd13bda70a5fd6a883938f4"
2024-11-25 19:22:05.508 | DEBUG    | livecheck.main:do_main:370 - Use updated date 20241112 for commit 0a721959116f6f86dbd13bda70a5fd6a883938f4
2024-11-25 19:22:05.509 | DEBUG    | livecheck.main:do_main:385 - Attempted to fix top_hash date but it failed. Ignoring this error.
2024-11-25 19:22:05.509 | DEBUG    | livecheck.main:do_main:386 - top_hash = 0a721959116f6f86dbd13bda70a5fd6a883938f4
2024-11-25 19:22:05.509 | DEBUG    | livecheck.main:do_main:394 - Comparing current ebuild version c9dad37dad64346afdff925fb409e6c6005b719a with live version 0a721959116f6f86dbd13bda70a5fd6a883938f4
2024-11-25 19:22:05.509 | DEBUG    | livecheck.main:do_main:400 - Updating ebuild /usr/portage/local/tatsh-overlay/media-video/vapoursynth-fsrcnn-ncnn-vulkan/vapoursynth-fsrcnn-ncnn-vulkan-20241112.ebuild to /usr/portage/local/tatsh-overlay/media-video/vapoursynth-fsrcnn-ncnn-vulkan/vapoursynth-fsrcnn-ncnn-vulkan-20241112.ebuild
2024-11-25 19:22:05.509 | DEBUG    | livecheck.main:do_main:416 - Incrementing revision to r1
2024-11-25 19:22:05.509 | DEBUG    | livecheck.main:do_main:418 - Migrating from /usr/portage/local/tatsh-overlay/media-video/vapoursynth-fsrcnn-ncnn-vulkan/vapoursynth-fsrcnn-ncnn-vulkan-20241112.ebuild to /usr/portage/local/tatsh-overlay/media-video/vapoursynth-fsrcnn-ncnn-vulkan/vapoursynth-fsrcnn-ncnn-vulkan-20241112-r1.ebuild
media-video/vapoursynth-fsrcnn-ncnn-vulkan: 20241112 (c9dad37dad64346afdff925fb409e6c6005b719a) -> 20241112-r1 (0a721959116f6f86dbd13bda70a5fd6a883938f4)
/usr/portage/local/tatsh-overlay/media-video/vapoursynth-fsrcnn-ncnn-vulkan/vapoursynth-fsrcnn-ncnn-vulkan-20241112.ebuild -> /usr/portage/local/tatsh-overlay/media-video/vapoursynth-fsrcnn-ncnn-vulkan/vapoursynth-fsrcnn-ncnn-vulkan-20241112-r1.ebuild
>>> Creating Manifest for /usr/portage/local/tatsh-overlay/media-video/vapoursynth-fsrcnn-ncnn-vulkan


 $ ls /usr/portage/local/tatsh-overlay/*.ebuild
ls: no se puede acceder a '/usr/portage/local/tatsh-overlay/*.ebuild': No existe el fichero o el directorio
</pre>