### PR TITLE
Fix error when file is missing during process files

### DIFF
--- a/livecheck/utils/portage.py
+++ b/livecheck/utils/portage.py
@@ -138,10 +138,13 @@ def catpkg_catpkgsplit(atom: str) -> tuple[str, str, str, str]:
 
 
 def get_first_src_uri(match: str, search_dir: str | None = None) -> str:
-    for uri in P.aux_get(match, ['SRC_URI'], mytree=search_dir):
-        for line in uri.split():
-            if line.startswith(('http://', 'https://')):
-                return line
+    try:
+        for uri in P.aux_get(match, ['SRC_URI'], mytree=search_dir):
+            for line in uri.split():
+                if line.startswith(('http://', 'https://')):
+                    return line
+    except KeyError:
+        pass
     return ''
 
 


### PR DESCRIPTION
Solve this error
<pre>
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/fran/projectos/livecheck/livecheck/__main__.py", line 3, in <module>
    main()
  File "/usr/lib/python3.12/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/fran/projectos/livecheck/livecheck/main.py", line 555, in main
    for cat, pkg, ebuild_version, version, url, regex, _use_vercmp in get_props(search_dir,
                                                                      ^^^^^^^^^^^^^^^^^^^^^
  File "/home/fran/projectos/livecheck/livecheck/main.py", line 118, in get_props
    src_uri = get_first_src_uri(match, repo_root)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/fran/projectos/livecheck/livecheck/utils/portage.py", line 141, in get_first_src_uri
    for uri in P.aux_get(match, ['SRC_URI'], mytree=search_dir):
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/portage/dbapi/porttree.py", line 683, in aux_get
    return loop.run_until_complete(
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/portage/util/_eventloop/asyncio_event_loop.py", line 155, in _run_until_complete
    return self._loop.run_until_complete(future)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/portage/dbapi/porttree.py", line 751, in async_aux_get
    raise PortageKeyError(mycpv)
portage.exception.PortageKeyError: 'sys-power/nut-2.8.0-r3'
</pre>