### PR TITLE
Restrict version and sync versions

### DIFF
--- a/.vscode/dictionary.txt
+++ b/.vscode/dictionary.txt
@@ -84,6 +84,7 @@ netcore
 nuanceur
 nugets
 numpy
+nvchecker
 paren
 parens
 pecl

--- a/README.md
+++ b/README.md
@@ -9,7 +9,17 @@
 ![GitHub](https://img.shields.io/github/license/Tatsh/livecheck)
 ![GitHub commits since latest release (by SemVer including pre-releases)](https://img.shields.io/github/commits-since/Tatsh/livecheck/v0.0.13/master)
 
-Tool for overlays to update ebuilds. Inspired by the MacPorts `port` subcommand of the same name.
+Tool for overlays to update ebuilds. Inspired by the MacPorts `port` subcommand of the same name
+or [nvchecker](https://github.com/lilydjwg/nvchecker).
+
+## Internal workings
+
+The script uses the first url of the ebuild using the SRC_URI variable to search for new versions,
+using logic for github, PyPI, PECL or if it is configured in the livecheck.json file within the
+same package directory.
+Then if you do not find a new version, try to use the repositories within the metadata.xml file
+That is why it is important to have the first download url well defined and thus automatically
+update the ebuild.
 
 ## Installation
 

--- a/livecheck/main.py
+++ b/livecheck/main.py
@@ -277,7 +277,15 @@ def get_props(search_dir: str,
         if debug or progress:
             logger.info(f'Processing {catpkg} version {ebuild_version}')
         last_version = hash_date = url = ''
-        if catpkg in settings.custom_livechecks:
+        if catpkg in settings.sync_version:
+            matches_sync = get_highest_matches2([settings.sync_version[catpkg]], '', settings)
+            if not matches_sync:
+                logger.error(f'No matches for {catpkg}')
+                continue
+            _, _, _, last_version = catpkg_catpkgsplit(matches_sync[0])
+            # remove -r* from version
+            last_version = re.sub(r'-r\d+$', '', last_version)
+        elif catpkg in settings.custom_livechecks:
             url, regex, _, version = settings.custom_livechecks[catpkg]
             last_version, hash_date, url = get_latest_regex_package(
                 ebuild_version, catpkg, settings, url, regex, version, devel, restrict_version)

--- a/livecheck/settings.py
+++ b/livecheck/settings.py
@@ -44,6 +44,7 @@ class LivecheckSettings:
     composer_packages: dict[str, bool]
     composer_path: dict[str, str]
     regex_version: dict[str, tuple[str, str]]
+    restrict_version: dict[str, str]
 
 
 class UnknownTransformationFunction(NameError):
@@ -74,6 +75,7 @@ def gather_settings(search_dir: str) -> LivecheckSettings:
     composer_packages: dict[str, bool] = {}
     composer_path: dict[str, str] = {}
     regex_version: dict[str, tuple[str, str]] = {}
+    restrict_version: dict[str, str] = {}
     for path in Path(search_dir).glob('**/livecheck.json'):
         logger.debug(f"Opening {path}")
         with path.open() as f:
@@ -185,12 +187,20 @@ def gather_settings(search_dir: str) -> LivecheckSettings:
                                path)
                 regex_version[catpkg] = (settings_parsed['pattern_version'],
                                          settings_parsed['replace_version'])
+            if 'restrict_version' in settings_parsed:
+                if settings_parsed.get('restrict_version').lower(
+                ) != 'full' and settings_parsed.get('restrict_version').lower(
+                ) != 'major' and settings_parsed.get('restrict_version').lower() != 'minor':
+                    logger.error(f'Invalid "restrict_version" in {path}')
+                    continue
+                restrict_version[catpkg] = settings_parsed['restrict_version'].lower()
 
-    return LivecheckSettings(
-        branches, checksum_livechecks, custom_livechecks, dotnet_projects, golang_packages,
-        ignored_packages, no_auto_update, semver, sha_sources, transformations, yarn_base_packages,
-        yarn_packages, jetbrains_packages, keep_old, gomodule_packages, gomodule_path,
-        nodejs_packages, nodejs_path, development, composer_packages, composer_path, regex_version)
+    return LivecheckSettings(branches, checksum_livechecks, custom_livechecks, dotnet_projects,
+                             golang_packages, ignored_packages, no_auto_update, semver, sha_sources,
+                             transformations, yarn_base_packages, yarn_packages, jetbrains_packages,
+                             keep_old, gomodule_packages, gomodule_path, nodejs_packages,
+                             nodejs_path, development, composer_packages, composer_path,
+                             regex_version, restrict_version)
 
 
 def check_instance(value: int | str | bool | list[str] | None,

--- a/livecheck/settings.py
+++ b/livecheck/settings.py
@@ -45,6 +45,7 @@ class LivecheckSettings:
     composer_path: dict[str, str]
     regex_version: dict[str, tuple[str, str]]
     restrict_version: dict[str, str]
+    sync_version: dict[str, str]
 
 
 class UnknownTransformationFunction(NameError):
@@ -76,6 +77,7 @@ def gather_settings(search_dir: str) -> LivecheckSettings:
     composer_path: dict[str, str] = {}
     regex_version: dict[str, tuple[str, str]] = {}
     restrict_version: dict[str, str] = {}
+    sync_version: dict[str, str] = {}
     for path in Path(search_dir).glob('**/livecheck.json'):
         logger.debug(f"Opening {path}")
         with path.open() as f:
@@ -194,13 +196,16 @@ def gather_settings(search_dir: str) -> LivecheckSettings:
                     logger.error(f'Invalid "restrict_version" in {path}')
                     continue
                 restrict_version[catpkg] = settings_parsed['restrict_version'].lower()
+            if 'sync_version' in settings_parsed:
+                check_instance(settings_parsed['sync_version'], 'sync_version', 'string', path)
+                sync_version[catpkg] = settings_parsed['sync_version']
 
     return LivecheckSettings(branches, checksum_livechecks, custom_livechecks, dotnet_projects,
                              golang_packages, ignored_packages, no_auto_update, semver, sha_sources,
                              transformations, yarn_base_packages, yarn_packages, jetbrains_packages,
                              keep_old, gomodule_packages, gomodule_path, nodejs_packages,
                              nodejs_path, development, composer_packages, composer_path,
-                             regex_version, restrict_version)
+                             regex_version, restrict_version, sync_version)
 
 
 def check_instance(value: int | str | bool | list[str] | None,

--- a/livecheck/special/regex.py
+++ b/livecheck/special/regex.py
@@ -37,7 +37,8 @@ def get_latest_regex_package(ebuild_version: str,
                              url: str,
                              regex: str,
                              version: str = '',
-                             development: bool = False) -> tuple[str, str, str]:
+                             development: bool = False,
+                             restrict_version: str = '') -> tuple[str, str, str]:
     parsed_uri = urlparse(url)
     logger.debug(f'Fetching {url}')
     headers = {}
@@ -68,6 +69,8 @@ def get_latest_regex_package(ebuild_version: str,
         return '', '', ''
     top_hash = ''
     for result in results:
+        if not result.startswith(restrict_version):
+            continue
         if not is_version_development(result) or development:
             top_hash = result
             break

--- a/livecheck/utils/portage.py
+++ b/livecheck/utils/portage.py
@@ -73,7 +73,7 @@ def get_highest_matches2(names: Sequence[str], repo_root: str,
     for name in names:
         if matches := P.xmatch('match-all', name):
             for m in matches:
-                if P.findname2(m)[1] == repo_root:
+                if not repo_root or P.findname2(m)[1] == repo_root:
                     cp_a, _, _, version_a = catpkg_catpkgsplit(m)
                     if '9999' in version_a or not cp_a or not version_a:
                         continue

--- a/man/livecheck.1
+++ b/man/livecheck.1
@@ -101,7 +101,7 @@ Utility functions.
 .SH SETTINGS
 .INDENT 0.0
 .TP
-.B class livecheck.settings.LivecheckSettings(branches: dict[str, str], checksum_livechecks: set[str], custom_livechecks: dict[str, tuple[str, str, bool, str]], dotnet_projects: dict[str, str], go_sum_uri: dict[str, str], ignored_packages: set[str], no_auto_update: set[str], semver: dict[str, bool], sha_sources: dict[str, str], transformations: collections.abc.Mapping[str, collections.abc.Callable[[str], str]], yarn_base_packages: dict[str, str], yarn_packages: dict[str, set[str]], jetbrains: dict[str, bool], keep_old: dict[str, bool], gomodule_packages: dict[str, bool], gomodule_path: dict[str, str], nodejs_packages: dict[str, bool], nodejs_path: dict[str, str], development: dict[str, bool], composer_packages: dict[str, bool], composer_path: dict[str, str], restrict_version: dict[str, str])
+.B class livecheck.settings.LivecheckSettings(branches: dict[str, str], checksum_livechecks: set[str], custom_livechecks: dict[str, tuple[str, str, bool, str]], dotnet_projects: dict[str, str], go_sum_uri: dict[str, str], ignored_packages: set[str], no_auto_update: set[str], semver: dict[str, bool], sha_sources: dict[str, str], transformations: collections.abc.Mapping[str, collections.abc.Callable[[str], str]], yarn_base_packages: dict[str, str], yarn_packages: dict[str, set[str]], jetbrains: dict[str, bool], keep_old: dict[str, bool], gomodule_packages: dict[str, bool], gomodule_path: dict[str, str], nodejs_packages: dict[str, bool], nodejs_path: dict[str, str], development: dict[str, bool], composer_packages: dict[str, bool], composer_path: dict[str, str], restrict_version: dict[str, str], sync_version: dict[str, str])
 .INDENT 7.0
 .TP
 .B dotnet_projects: dict[str, str]

--- a/man/livecheck.1
+++ b/man/livecheck.1
@@ -101,7 +101,7 @@ Utility functions.
 .SH SETTINGS
 .INDENT 0.0
 .TP
-.B class livecheck.settings.LivecheckSettings(branches: dict[str, str], checksum_livechecks: set[str], custom_livechecks: dict[str, tuple[str, str, bool, str]], dotnet_projects: dict[str, str], go_sum_uri: dict[str, str], ignored_packages: set[str], no_auto_update: set[str], semver: dict[str, bool], sha_sources: dict[str, str], transformations: collections.abc.Mapping[str, collections.abc.Callable[[str], str]], yarn_base_packages: dict[str, str], yarn_packages: dict[str, set[str]], jetbrains: dict[str, bool], keep_old: dict[str, bool], gomodule_packages: dict[str, bool], gomodule_path: dict[str, str], nodejs_packages: dict[str, bool], nodejs_path: dict[str, str], development: dict[str, bool], composer_packages: dict[str, bool], composer_path: dict[str, str])
+.B class livecheck.settings.LivecheckSettings(branches: dict[str, str], checksum_livechecks: set[str], custom_livechecks: dict[str, tuple[str, str, bool, str]], dotnet_projects: dict[str, str], go_sum_uri: dict[str, str], ignored_packages: set[str], no_auto_update: set[str], semver: dict[str, bool], sha_sources: dict[str, str], transformations: collections.abc.Mapping[str, collections.abc.Callable[[str], str]], yarn_base_packages: dict[str, str], yarn_packages: dict[str, set[str]], jetbrains: dict[str, bool], keep_old: dict[str, bool], gomodule_packages: dict[str, bool], gomodule_path: dict[str, str], nodejs_packages: dict[str, bool], nodejs_path: dict[str, str], development: dict[str, bool], composer_packages: dict[str, bool], composer_path: dict[str, str], restrict_version: dict[str, str])
 .INDENT 7.0
 .TP
 .B dotnet_projects: dict[str, str]


### PR DESCRIPTION
* allow restricting versions, so you can only update a lower version level, without jumping to a higher version
 ** At the moment it is only active for searches using regex, when I have time I will apply it to the rest of the version searches
* allows ebuild to be synchronized with versions so that they maintain the same versions
For example, if we use certbot-dns-cloudflare that depends on app-crypt/certbot, those that depend on it will also do so when the latter is updated.