### PR TITLE
simplify parameters in functions

### DIFF
--- a/livecheck/settings.py
+++ b/livecheck/settings.py
@@ -5,13 +5,12 @@ from pathlib import Path
 import json
 from urllib.parse import urlparse
 
+from loguru import logger
 import livecheck.special.handlers as sc
 
 from . import utils
 
 __all__ = ('LivecheckSettings', 'gather_settings')
-
-from loguru import logger
 
 
 @dataclass
@@ -23,8 +22,8 @@ class LivecheckSettings:
     '''Dictionary of catpkg to project or solution file (base name only).'''
     go_sum_uri: dict[str, str]
     '''
-    Dictionary of catpkg to full URI to ``go.sum`` with ``@PV@`` used for where version gets
-    placed.
+    Dictionary of catpkg to full URI to ``go.sum`` with ``@PV@`` used for
+    where version gets placed.
     '''
     type_packages: dict[str, str]
     no_auto_update: set[str]
@@ -46,6 +45,18 @@ class LivecheckSettings:
     regex_version: dict[str, tuple[str, str]]
     restrict_version: dict[str, str]
     sync_version: dict[str, str]
+    '''Settings from command line flag.'''
+    auto_update_flag: bool = False
+    debug_flag: bool = False
+    development_flag: bool = False
+    git_flag: bool = False
+    keep_old_flag: bool = False
+    progress_flag: bool = False
+    '''Setting form internal process.'''
+    restrict_version_process: str = ''
+
+    def is_devel(self, catpkg: str) -> bool:
+        return self.development.get(catpkg, self.development_flag)
 
 
 class UnknownTransformationFunction(NameError):
@@ -88,7 +99,7 @@ def gather_settings(search_dir: str) -> LivecheckSettings:
             except json.JSONDecodeError as e:
                 logger.error(f"Error parsing file {path}: {e}")
                 continue
-            if settings_parsed.get('type') != None:
+            if settings_parsed.get('type') is not None:
                 if settings_parsed.get('type').lower() == 'none':
                     type_packages[catpkg] = 'none'
                 elif settings_parsed.get('type').lower() == 'regex':
@@ -212,25 +223,25 @@ def gather_settings(search_dir: str) -> LivecheckSettings:
 
 def check_instance(value: int | str | bool | list[str] | None,
                    key: str,
-                   type: str,
+                   dtype: str,
                    path: str | object,
                    specific_value: bool | int | str | None = None) -> None:
     is_type = False
-    if type == 'bool':
+    if dtype == 'bool':
         is_type = isinstance(value, bool)
-    elif type == 'int':
+    elif dtype == 'int':
         is_type = isinstance(value, int)
-    elif type == 'string':
+    elif dtype == 'string':
         is_type = isinstance(value, str)
-    elif type == 'none':
-        is_type = value == None
-    elif type == 'list':
+    elif dtype == 'none':
+        is_type = value is None
+    elif dtype == 'list':
         is_type = isinstance(value, list)
-    elif type == 'url':
+    elif dtype == 'url':
         if isinstance(value, str):
             parsed_url = urlparse(value)
             is_type = all([parsed_url.scheme, parsed_url.netloc])
-    elif type == 'regex':
+    elif dtype == 'regex':
         if isinstance(value, str):
             try:
                 re.compile(value)
@@ -239,7 +250,8 @@ def check_instance(value: int | str | bool | list[str] | None,
                 is_type = False
 
     if not is_type:
-        logger.error(f"Value \"{value}\" in key \"{key}\" is not of type \"{type}\" in file {path}")
+        logger.error(
+            f"Value \"{value}\" in key \"{key}\" is not of type \"{dtype}\" in file {path}")
 
     if specific_value is not None and value != specific_value:
         logger.error(

--- a/livecheck/special/bitbucket.py
+++ b/livecheck/special/bitbucket.py
@@ -14,7 +14,7 @@ BITBUCKET_DOWNLOAD_URL = 'https://api.bitbucket.org/2.0/repositories/%s/%s/downl
 MAX_ITERATIONS = 4
 
 
-def get_latest_bitbucket_package(path: str, ebuild: str, development: bool, restrict_version: str,
+def get_latest_bitbucket_package(path: str, ebuild: str,
                                  settings: LivecheckSettings) -> tuple[str, str]:
     workspace, repository = path.strip("/").split('/')[:2]
 
@@ -50,8 +50,7 @@ def get_latest_bitbucket_package(path: str, ebuild: str, development: bool, rest
         url = data.get('next')
         iteration_count += 1
 
-    if last_version := get_last_version(results, repository, ebuild, development, restrict_version,
-                                        settings):
+    if last_version := get_last_version(results, repository, ebuild, settings):
         return last_version['version'], last_version["id"]
 
     return '', ''

--- a/livecheck/special/github.py
+++ b/livecheck/special/github.py
@@ -30,7 +30,7 @@ def extract_owner_repo(url: str) -> tuple[str, str, str]:
     return '', '', ''
 
 
-def get_latest_github_package(url: str, ebuild: str, development: bool, restrict_version: str,
+def get_latest_github_package(url: str, ebuild: str,
                               settings: LivecheckSettings) -> tuple[str, str]:
     domain, owner, repo = extract_owner_repo(url)
     if not owner or not repo:
@@ -47,8 +47,7 @@ def get_latest_github_package(url: str, ebuild: str, development: bool, restrict
         if tag := (tag_id.split('/')[-1] if tag_id and '/' in tag_id else ''):
             results.append({"tag": tag, "id": tag})
 
-    if last_version := get_last_version(results, repo, ebuild, development, restrict_version,
-                                        settings):
+    if last_version := get_last_version(results, repo, ebuild, settings):
         if not (r := get_content(
                 f"https://api.github.com/repos/{owner}/{repo}/git/refs/tags/{last_version['id']}")):
             return last_version['version'], ''

--- a/livecheck/special/gitlab.py
+++ b/livecheck/special/gitlab.py
@@ -1,4 +1,3 @@
-import re
 from urllib.parse import urlparse, quote
 
 from ..settings import LivecheckSettings
@@ -22,7 +21,7 @@ def extract_domain_and_namespace(url: str) -> tuple[str, str, str]:
     return parsed.netloc, path, path.split('/')[-1]
 
 
-def get_latest_gitlab_package(url: str, ebuild: str, development: bool, restrict_version: str,
+def get_latest_gitlab_package(url: str, ebuild: str,
                               settings: LivecheckSettings) -> tuple[str, str]:
 
     domain, path_with_namespace, repo = extract_domain_and_namespace(url)
@@ -40,8 +39,7 @@ def get_latest_gitlab_package(url: str, ebuild: str, development: bool, restrict
             "id": tag.get("commit", {}).get("id", ""),
         })
 
-    if last_version := get_last_version(results, repo, ebuild, development, restrict_version,
-                                        settings):
+    if last_version := get_last_version(results, repo, ebuild, settings):
         return last_version['version'], last_version["id"]
 
     return '', ''

--- a/livecheck/special/metacpan.py
+++ b/livecheck/special/metacpan.py
@@ -12,8 +12,7 @@ def extract_perl_package(path: str) -> str:
     return match.group(1) if match else ''
 
 
-def get_latest_metacpan_package(path: str, ebuild: str, development: bool, restrict_version: str,
-                                settings: LivecheckSettings) -> str:
+def get_latest_metacpan_package(path: str, ebuild: str, settings: LivecheckSettings) -> str:
     package_name = extract_perl_package(path)
 
     results = []
@@ -27,8 +26,7 @@ def get_latest_metacpan_package(path: str, ebuild: str, development: bool, restr
     if response := get_content(f"https://fastapi.metacpan.org/v1/release/{package_name}"):
         results.append({"tag": response.json().get('version')})
 
-    last_version = get_last_version(results, package_name, ebuild, development, restrict_version,
-                                    settings)
+    last_version = get_last_version(results, package_name, ebuild, settings)
     if last_version:
         return last_version['version']
 

--- a/livecheck/special/pecl.py
+++ b/livecheck/special/pecl.py
@@ -1,7 +1,7 @@
 import xml.etree.ElementTree as etree
 
 from ..settings import LivecheckSettings
-from ..utils.portage import get_last_version
+from ..utils.portage import get_last_version, catpkg_catpkgsplit
 from ..utils import get_content
 
 __all__ = ["get_latest_pecl_package"]
@@ -11,8 +11,9 @@ PECL_DOWNLOAD_URL = 'https://pecl.php.net/rest/r/%s/allreleases.xml'
 NAMESPACE = "{http://pear.php.net/dtd/rest.allreleases}"
 
 
-def get_latest_pecl_package(program_name: str, ebuild: str, development: bool,
-                            restrict_version: str, settings: LivecheckSettings) -> str:
+def get_latest_pecl_package(ebuild: str, settings: LivecheckSettings) -> str:
+    catpkg, _, program_name, _ = catpkg_catpkgsplit(ebuild)
+
     # Remove 'pecl-' prefix if present
     if program_name.startswith('pecl-'):
         program_name = program_name.replace('pecl-', '', 1)
@@ -26,13 +27,12 @@ def get_latest_pecl_package(program_name: str, ebuild: str, development: bool,
     for release in etree.fromstring(r.text).findall(f"{NAMESPACE}r"):
         stability = release.find(f"{NAMESPACE}s")
         stability = stability.text if stability is not None else None
-        if development or stability == 'stable':
+        if settings.is_devel(catpkg) or stability == 'stable':
             version = release.find(f"{NAMESPACE}v")
             version = version.text if version is not None else None
             results.append({"tag": version})
 
-    if last_version := get_last_version(results, '', ebuild, development, restrict_version,
-                                        settings):
+    if last_version := get_last_version(results, '', ebuild, settings):
         return last_version['version']
 
     return ''

--- a/livecheck/special/regex.py
+++ b/livecheck/special/regex.py
@@ -26,9 +26,8 @@ def adjust_regex(version: str, regex: str, settings: LivecheckSettings, cp: str,
     return re.findall(regex, text)
 
 
-def get_latest_regex_package(ebuild: str, settings: LivecheckSettings, url: str, regex: str,
-                             version: str, development: bool,
-                             restrict_version: str) -> tuple[str, str, str]:
+def get_latest_regex_package(ebuild: str, url: str, regex: str, version: str,
+                             settings: LivecheckSettings) -> tuple[str, str, str]:
 
     cp, _, _, ebuild_version = catpkg_catpkgsplit(ebuild)
 
@@ -53,8 +52,7 @@ def get_latest_regex_package(ebuild: str, settings: LivecheckSettings, url: str,
         else:
             results.append({"tag": result})
 
-    if last_version := get_last_version(results, '', ebuild, development, restrict_version,
-                                        settings):
+    if last_version := get_last_version(results, '', ebuild, settings):
         return last_version['version'], '', ''
 
     return '', '', ''

--- a/livecheck/special/rubygems.py
+++ b/livecheck/special/rubygems.py
@@ -1,5 +1,5 @@
 from ..settings import LivecheckSettings
-from ..utils.portage import get_last_version
+from ..utils.portage import get_last_version, catpkg_catpkgsplit
 from ..utils import get_content
 
 __all__ = ["get_latest_rubygems_package"]
@@ -7,8 +7,9 @@ __all__ = ["get_latest_rubygems_package"]
 RUBYGEMS_DOWNLOAD_URL = 'https://rubygems.org/api/v1/versions/%s.json'
 
 
-def get_latest_rubygems_package(gem_name: str, ebuild: str, development: bool,
-                                restrict_version: str, settings: LivecheckSettings) -> str:
+def get_latest_rubygems_package(ebuild: str, settings: LivecheckSettings) -> str:
+    catpkg, _, gem_name, _ = catpkg_catpkgsplit(ebuild)
+
     url = RUBYGEMS_DOWNLOAD_URL % (gem_name)
 
     if not (response := get_content(url)):
@@ -16,11 +17,10 @@ def get_latest_rubygems_package(gem_name: str, ebuild: str, development: bool,
 
     results = []
     for release in response.json():
-        if development or not release.get("prerelease", False):
+        if settings.is_devel(catpkg) or not release.get("prerelease", False):
             results.append({"tag": release.get("number", "")})
 
-    if last_version := get_last_version(results, gem_name, ebuild, development, restrict_version,
-                                        settings):
+    if last_version := get_last_version(results, gem_name, ebuild, settings):
         return last_version['version']
 
     return ''

--- a/livecheck/special/sourceforge.py
+++ b/livecheck/special/sourceforge.py
@@ -28,8 +28,7 @@ def extract_repository(url: str, pkg: str) -> str:
     return pkg
 
 
-def get_latest_sourceforge_package(src_uri: str, ebuild: str, development: bool,
-                                   restrict_version: str, settings: LivecheckSettings) -> str:
+def get_latest_sourceforge_package(src_uri: str, ebuild: str, settings: LivecheckSettings) -> str:
 
     _, pkg, _, _ = catpkg_catpkgsplit(ebuild)
 
@@ -47,8 +46,7 @@ def get_latest_sourceforge_package(src_uri: str, ebuild: str, development: bool,
         if version and get_archive_extension(version):
             results.append({"tag": version})
 
-    if last_version := get_last_version(results, repository, ebuild, development, restrict_version,
-                                        settings):
+    if last_version := get_last_version(results, repository, ebuild, settings):
         return last_version['version']
 
     return ''

--- a/livecheck/utils/portage.py
+++ b/livecheck/utils/portage.py
@@ -303,8 +303,8 @@ def unpack_ebuild(ebuild_path: str) -> str:
     return ''
 
 
-def get_last_version(results: list[dict[str, str]], repo: str, ebuild: str, development: bool,
-                     restrict_version: str, settings: LivecheckSettings) -> dict[str, str]:
+def get_last_version(results: list[dict[str, str]], repo: str, ebuild: str,
+                     settings: LivecheckSettings) -> dict[str, str]:
     logger.debug('Result count: %d', len(results))
 
     catpkg, _, _, ebuild_version = catpkg_catpkgsplit(ebuild)
@@ -329,10 +329,10 @@ def get_last_version(results: list[dict[str, str]], repo: str, ebuild: str, deve
         except ValueError:
             logger.debug("Skip non-version tag: %s", version)
             continue
-        if not version.startswith(restrict_version):
+        if not version.startswith(settings.restrict_version_process):
             continue
         if is_version_development(ebuild_version) or (not is_version_development(version)
-                                                      or development):
+                                                      or settings.is_devel(catpkg)):
             last = last_version.get('version', '')
             if not last or compare_versions(last, version):
                 last_version = result.copy()


### PR DESCRIPTION
Use settings to store the flags used from the command line and thus reduce the overhead of parameters that must be maintained between functions.
Fix minor python warning issues to make the checker happier.