### PR TITLE
migrate gist

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,19 +116,25 @@ action directory there can be several scripts that are executed in order of name
 - `sync_version` - string - Category and ebuild with version to sync.
 - `transformation_function` - string - Function to use to transform the version string.
   Currently only `dotize` is supported. Others are for internal use.
-- `type` - string - Only one `none`, `davinci`, `regex`, or `checksum`.
+- `type` - string - Only one `none`, `davinci`, `regex`, `directory`, `commit`,
+  `repology` or `checksum`.
 
 Use the pattern to adjust the version using a regular expression
 
 - `pattern_version` - string - The pattern string
 - `replace_version` - string - The replace string
 
-Only then `type` is `regex`
+Only then `type` is `regex` or `directory`
 
 - `url` - URL of the document to run regular expressions against. Required
+
+Only then `type` is `regex`
+
 - `regex` - string - The regular expression to use. Required
-- `use_vercmp` - boolean - if `vercmp` from Portage should be used. Default: `true`.
-- `version` - string - Version of package. Default: `None`.
+
+Only then `type` is `repology`
+
+- `package` - string - The package to search in repology. Required
 
 ## Development use
 

--- a/livecheck/constants.py
+++ b/livecheck/constants.py
@@ -3,18 +3,9 @@ from typing import Final
 
 from .utils import prefix_v
 
-__all__ = ('GIST_HOSTNAMES', 'PREFIX_RE', 'RSS_NS', 'SEMVER_RE', 'SUBMODULES', 'TAG_NAME_FUNCTIONS')
+__all__ = ('RSS_NS', 'SUBMODULES', 'TAG_NAME_FUNCTIONS')
 
-GIST_HOSTNAMES = {'gist.github.com', 'gist.githubusercontent.com'}
-
-PREFIX_RE: Final[str] = r'(^[^0-9]+)[0-9]'
 RSS_NS = {'': 'http://www.w3.org/2005/Atom'}
-SEMVER_RE: Final[str] = (r'^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.'
-                         r'(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]'
-                         r'\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|'
-                         r'\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+'
-                         r'(?P<buildmetadata>[0-9a-zA-Z-]+'
-                         r'(?:\.[0-9a-zA-Z-]+)*))?$')
 
 SUBMODULES: Final[Mapping[str, set[str | tuple[str, str]]]] = {
     'app-misc/tasksh': {'src/libshared'},

--- a/livecheck/main.py
+++ b/livecheck/main.py
@@ -17,7 +17,6 @@ from loguru import logger
 import click
 
 from .constants import (
-    GIST_HOSTNAMES,
     SUBMODULES,
     TAG_NAME_FUNCTIONS,
 )
@@ -47,6 +46,7 @@ from .special.composer import (
 from .special.davinci import get_latest_davinci_package
 from .special.directory import get_latest_directory_package
 from .special.dotnet import check_dotnet_requirements, update_dotnet_ebuild
+from .special.gist import get_latest_gist_package, is_gist
 from .special.github import (
     GITHUB_METADATA,
     get_latest_github,
@@ -150,10 +150,8 @@ def parse_url(repo_root: str, src_uri: str, ebuild: str,
         return last_version, top_hash, hash_date, url
 
     logger.debug(f'Parsed URI: {parsed_uri}')
-    if parsed_uri.hostname in GIST_HOSTNAMES:
-        home = P.aux_get(ebuild, ['HOMEPAGE'], mytree=repo_root)[0]
-        last_version, hash_date, url = get_latest_regex_package(
-            ebuild, f'{home}/revisions', r'<relative-time datetime="([0-9-]{10})', '', settings)
+    if is_gist(src_uri):
+        top_hash, hash_date = get_latest_gist_package(src_uri)
     elif is_github(src_uri):
         last_version, top_hash, hash_date = get_latest_github(src_uri, ebuild, settings)
     elif is_sourcehut(src_uri):

--- a/livecheck/main.py
+++ b/livecheck/main.py
@@ -624,6 +624,10 @@ def main(
         if not Path(repo_root, '.git').is_dir():
             logger.error(f'Directory {repo_root} is not a git repository')
             raise click.Abort
+        # Check if .git is a writeable directory
+        if not os.access(Path(repo_root, '.git'), os.W_OK):
+            logger.error(f'Directory {repo_root}/.git is not writable')
+            raise click.Abort
         # Check if git is installed
         if not check_program('git', '--version'):
             logger.error('Git is not installed')

--- a/livecheck/main.py
+++ b/livecheck/main.py
@@ -288,15 +288,14 @@ def get_props(
         elif settings.type_packages.get(catpkg) == TYPE_METADATA:
             last_version, top_hash, hash_date, url = parse_metadata(repo_root, match, settings)
         elif settings.type_packages.get(catpkg) == TYPE_DIRECTORY:
-            url, _, _, _ = settings.custom_livechecks[catpkg]
+            url, _ = settings.custom_livechecks[catpkg]
             last_version, url = get_latest_directory_package(url, match, settings)
         elif settings.type_packages.get(catpkg) == TYPE_REPOLOGY:
-            package, _, _, _ = settings.custom_livechecks[catpkg]
+            package, _ = settings.custom_livechecks[catpkg]
             last_version = get_latest_repology(match, settings, package)
         elif settings.type_packages.get(catpkg) == TYPE_REGEX:
-            url, regex, _, version = settings.custom_livechecks[catpkg]
-            last_version, hash_date, url = get_latest_regex_package(match, url, regex, version,
-                                                                    settings)
+            url, regex = settings.custom_livechecks[catpkg]
+            last_version, hash_date, url = get_latest_regex_package(match, url, regex, settings)
         elif settings.type_packages.get(catpkg) == TYPE_CHECKSUM:
             manifest_file = Path(repo_root) / catpkg / 'Manifest'
             bn = Path(src_uri).name
@@ -322,8 +321,7 @@ def get_props(
                             match,
                             dict(cast(Sequence[tuple[str, str]], chunks(fields_s.split(' '),
                                                                         2)))['SHA512'],
-                            f'data:{hashlib.sha512(r.content).hexdigest()}', r'^[0-9a-f]+$',
-                            settings)
+                            f'data:{hashlib.sha512(r.content).hexdigest()}', settings)
                         break
             except FileNotFoundError:
                 pass

--- a/livecheck/settings.py
+++ b/livecheck/settings.py
@@ -46,7 +46,7 @@ SETTINGS_TYPES = {
 @dataclass
 class LivecheckSettings:
     branches: dict[str, str] = field(default_factory=dict)
-    custom_livechecks: dict[str, tuple[str, str, bool, str]] = field(default_factory=dict)
+    custom_livechecks: dict[str, tuple[str, str]] = field(default_factory=dict)
     dotnet_projects: dict[str, str] = field(default_factory=dict)
     '''Dictionary of catpkg to project or solution file (base name only).'''
     go_sum_uri: dict[str, str] = field(default_factory=dict)
@@ -98,7 +98,7 @@ def gather_settings(search_dir: str) -> LivecheckSettings:
     import livecheck.special.handlers as sc
 
     branches: dict[str, str] = {}
-    custom_livechecks: dict[str, tuple[str, str, bool, str]] = {}
+    custom_livechecks: dict[str, tuple[str, str]] = {}
     dotnet_projects: dict[str, str] = {}
     golang_packages: dict[str, str] = {}
     type_packages: dict[str, str] = {}
@@ -140,19 +140,17 @@ def gather_settings(search_dir: str) -> LivecheckSettings:
                     if settings_parsed.get('regex') is None:
                         logger.error(f'No "regex" in {path}')
                         continue
-                    custom_livechecks[catpkg] = (settings_parsed['url'], settings_parsed['regex'],
-                                                 settings_parsed.get('use_vercmp', True),
-                                                 settings_parsed.get('version', ''))
+                    custom_livechecks[catpkg] = (settings_parsed['url'], settings_parsed['regex'])
                 if _type == TYPE_REPOLOGY:
                     if settings_parsed.get('package') is None:
                         logger.error(f'No "package" in {path}')
                         continue
-                    custom_livechecks[catpkg] = (settings_parsed.get('package'), '', False, '')
+                    custom_livechecks[catpkg] = (settings_parsed.get('package'), '')
                 if _type == TYPE_DIRECTORY:
                     if settings_parsed.get('url') is None:
                         logger.error(f'No "url" in {path}')
                         continue
-                    custom_livechecks[catpkg] = (settings_parsed.get('url'), '', False, '')
+                    custom_livechecks[catpkg] = (settings_parsed.get('url'), '')
                 if _type not in SETTINGS_TYPES:
                     logger.error(f'Unknown "type" in {path}')
                 else:

--- a/livecheck/special/bitbucket.py
+++ b/livecheck/special/bitbucket.py
@@ -36,9 +36,9 @@ def get_latest_bitbucket_package(path: str, ebuild: str,
     iteration_count = 0
 
     while url and iteration_count < MAX_ITERATIONS:
-        if not (response := get_content(url)):
+        if not (r := get_content(url)):
             break
-        data = response.json()
+        data = r.json()
 
         results.extend({
             "tag": item.get('name', ''),

--- a/livecheck/special/gist.py
+++ b/livecheck/special/gist.py
@@ -1,0 +1,50 @@
+from datetime import datetime
+from urllib.parse import urlparse
+import re
+
+from ..utils import get_content
+
+__all__ = ("get_latest_gist_package", "is_gist")
+
+GIST_COMMIT_URL = 'https://api.github.com/gists/%s'
+
+
+def extract_id(url: str) -> str:
+    m = re.search(r'https?://gist\.github\.com/(?:[^/]+/)?([a-f0-9]+)', url)
+    if not m:
+        m = re.search(r'https?://gist\.githubusercontent\.com/[^/]+/([a-f0-9]+)/', url)
+    gist_id = m.group(1) if m else ''
+    if not gist_id:
+        p = urlparse(url)
+        for part in reversed(p.path.rstrip("/").split("/")):
+            if re.fullmatch(r"[a-f0-9]{5,}", part):
+                gist_id = part
+                break
+    return gist_id
+
+
+def get_latest_gist_package(url: str) -> tuple[str, str]:
+    if not (gist_id := extract_id(url)):
+        return '', ''
+
+    url = GIST_COMMIT_URL % (gist_id)
+    if not (r := get_content(url)):
+        return '', ''
+
+    history = r.json().get("history", [])
+    if not history:
+        return '', ''
+    latest = max(history, key=lambda x: x.get("committed_at", ""))
+
+    d = latest.get("committed_at")
+    try:
+        dt = datetime.fromisoformat(d.replace("Z", "+00:00"))
+        formatted_date = dt.strftime("%Y%m%d")
+    except ValueError:
+        formatted_date = d[:10]
+
+    return latest.get("version"), formatted_date
+
+
+def is_gist(url: str) -> bool:
+    return bool(extract_id(url))

--- a/livecheck/special/gist.py
+++ b/livecheck/special/gist.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from urllib.parse import urlparse
 import re
 
 from ..utils import get_content
@@ -13,14 +12,7 @@ def extract_id(url: str) -> str:
     m = re.search(r'https?://gist\.github\.com/(?:[^/]+/)?([a-f0-9]+)', url)
     if not m:
         m = re.search(r'https?://gist\.githubusercontent\.com/[^/]+/([a-f0-9]+)/', url)
-    gist_id = m.group(1) if m else ''
-    if not gist_id:
-        p = urlparse(url)
-        for part in reversed(p.path.rstrip("/").split("/")):
-            if re.fullmatch(r"[a-f0-9]{5,}", part):
-                gist_id = part
-                break
-    return gist_id
+    return m.group(1) if m else ''
 
 
 def get_latest_gist_package(url: str) -> tuple[str, str]:

--- a/livecheck/special/metacpan.py
+++ b/livecheck/special/metacpan.py
@@ -9,6 +9,8 @@ __all__ = ("get_latest_metacpan_package", "is_metacpan", "METACPAN_METADATA",
            "get_latest_metacpan_metadata")
 
 METACPAN_METADATA = 'cpan'
+METACPAN_DOWNLOAD_URL1 = 'https://fastapi.metacpan.org/v1/release/_search?q=distribution:%s'
+METACPAN_DOWNLOAD_URL2 = 'https://fastapi.metacpan.org/v1/release/%s'
 
 
 def extract_perl_package(path: str) -> str:
@@ -24,14 +26,15 @@ def get_latest_metacpan_package(path: str, ebuild: str, settings: LivecheckSetti
 def get_latest_metacpan_package2(package_name: str, ebuild: str,
                                  settings: LivecheckSettings) -> str:
     results: list[dict[str, str]] = []
-    if r := get_content(
-            f"https://fastapi.metacpan.org/v1/release/_search?q=distribution:{package_name}"):
+    url = METACPAN_DOWNLOAD_URL1 % (package_name)
+    if r := get_content(url):
         for hit in r.json().get("hits", {}).get("hits", []):
             results.extend([{"tag": hit["_source"]["version"]}])
 
     # Many times it does not exist as in the previous list,
     # that is why the latest version is checked again.
-    if r := get_content(f"https://fastapi.metacpan.org/v1/release/{package_name}"):
+    url = METACPAN_DOWNLOAD_URL2 % (package_name)
+    if r := get_content(url):
         results.append({"tag": r.json().get('version')})
 
     last_version = get_last_version(results, package_name, ebuild, settings)

--- a/livecheck/special/regex.py
+++ b/livecheck/special/regex.py
@@ -11,7 +11,7 @@ from ..utils.portage import catpkg_catpkgsplit, get_last_version
 __all__ = ('get_latest_regex_package',)
 
 
-def get_latest_regex_package(ebuild: str, url: str, regex: str, version: str,
+def get_latest_regex_package(ebuild: str, url: str, regex: str,
                              settings: LivecheckSettings) -> tuple[str, str, str]:
 
     _, _, _, ebuild_version = catpkg_catpkgsplit(ebuild)

--- a/livecheck/special/utils.py
+++ b/livecheck/special/utils.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Any
 import logging
 import os
 import tarfile
@@ -47,7 +46,7 @@ def search_ebuild(ebuild: str, archive: str, path: str | None = None) -> tuple[s
 
     if path:
         # Search first directory in temp_dir
-        for root, _, files in os.walk(temp_dir):
+        for root, _, _ in os.walk(temp_dir):
             # check if relative path is in the root
             if path in root:
                 return root, temp_dir
@@ -120,8 +119,8 @@ class EbuildTempFile:
                                         dir=self.ebuild.parent).name)
         return self.temp_file
 
-    def __exit__(self, exc_type: type | None, exc_value: BaseException | None,
-                 traceback: Any | None) -> bool:
+    def __exit__(self, exc_type: object, exc_value: BaseException | None,
+                 traceback: object) -> bool:
         if exc_type is None:
             if not self.temp_file or not self.temp_file.exists() or self.temp_file.stat(
             ).st_size == 0:

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "gen-manpage": "poetry run sphinx-build -T -E -b man -d docs/_build/doctrees -D language=en docs man && mv man/livecheck.1 man/livecheck.1",
     "mypy": "poetry run mypy .",
     "qa": "yarn mypy && yarn ruff && yarn check-spelling && yarn check-formatting",
-    "ruff": "poetry run ruff .",
-    "ruff:fix": "poetry run ruff --fix .",
+    "ruff": "poetry run ruff check .",
+    "ruff:fix": "poetry run ruff check --fix .",
     "test": "poetry run pytest"
   },
   "version": "0.0.13"

--- a/tests/special/test_gitlab.py
+++ b/tests/special/test_gitlab.py
@@ -4,7 +4,7 @@ from livecheck.special.gitlab import extract_domain_and_namespace
 
 
 @pytest.mark.parametrize(
-    "url, expected",
+    ("url", "expected"),
     [("https://gitlab.com/group/project", ("gitlab.com", "group/project", "project")),
      ("https://notgitlab.com/group/project", ("", "", "")),
      ("https://gitlab.es/group/project", ("", "", "")),


### PR DESCRIPTION
I have checked all your ebuilds that use gist and I have seen that they now update correctly mpv-shader/krig-bilateral and mpv-shader/ssim-downscaler

<pre>
2025-02-17 17:12:31.646 | INFO     | livecheck.main:main:637 - search_dir=/usr/portage/local/tatsh-overlay/mpv-shader/krig-bilateral repo_root=/usr/portage/local/tatsh-overlay repo_name=tatsh-overlay
DEBUG:asyncio:Using selector: EpollSelector
2025-02-17 17:12:31.658 | INFO     | livecheck.main:get_props:254 - Found 1 ebuilds
2025-02-17 17:12:31.658 | INFO     | livecheck.main:get_props:269 - Processing mpv-shader/krig-bilateral version 20231027
2025-02-17 17:12:31.658 | DEBUG    | livecheck.main:parse_url:152 - Parsed URI: ParseResult(scheme='https', netloc='gist.github.com', path='/igv/a015fc885d5c22e6891820ad89555637/archive/7c151e0af2281ae6657809be1f3c5efe0e325c38.zip', params='', query='', fragment='')
2025-02-17 17:12:31.658 | DEBUG    | livecheck.utils:get_content:139 - Fetching https://api.github.com/gists/a015fc885d5c22e6891820ad89555637
DEBUG:keyring.backend:Loading KWallet
DEBUG:keyring.backend:Loading SecretService
DEBUG:keyring.backend:Loading Windows
DEBUG:keyring.backend:Loading chainer
DEBUG:keyring.backend:Loading libsecret
DEBUG:keyring.backend:Loading macOS
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): api.github.com:443
DEBUG:urllib3.connectionpool:https://api.github.com:443 "GET /gists/a015fc885d5c22e6891820ad89555637 HTTP/1.1" 200 None
2025-02-17 17:12:32.138 | DEBUG    | livecheck.main:get_props:354 - Inserting mpv-shader/krig-bilateral: 20231027 ->  : 038064821c5f768dfc6c00261535018d5932cdd5
2025-02-17 17:12:32.139 | DEBUG    | livecheck.main:do_main:452 - Incrementing revision to r1
2025-02-17 17:12:32.139 | DEBUG    | livecheck.main:do_main:454 - top_hash = 20231027-r1
2025-02-17 17:12:32.139 | DEBUG    | livecheck.main:do_main:456 - Comparing current ebuild version 20231027 with live version 20231027-r1
2025-02-17 17:12:32.139 | DEBUG    | livecheck.main:do_main:463 - Migrating from /usr/portage/local/tatsh-overlay/mpv-shader/krig-bilateral/krig-bilateral-20231027.ebuild to /usr/portage/local/tatsh-overlay/mpv-shader/krig-bilateral/krig-bilateral-20231027-r1.ebuild
mpv-shader/krig-bilateral: 20231027 (7c151e0af2281ae6657809be1f3c5efe0e325c38) -> 20231027-r1 (038064821c5f768dfc6c00261535018d5932cdd5)
</pre>


<pre>
!!! Section 'HomeAssistantRepository' in repos.conf has name different from repository name 'HomeAssistantLocalRep' set inside repository
2025-02-17 17:15:11.537 | INFO     | livecheck.main:main:637 - search_dir=/usr/portage/local/tatsh-overlay/mpv-shader/ssim-downscaler repo_root=/usr/portage/local/tatsh-overlay repo_name=tatsh-overlay
DEBUG:asyncio:Using selector: EpollSelector
2025-02-17 17:15:11.549 | INFO     | livecheck.main:get_props:254 - Found 1 ebuilds
2025-02-17 17:15:11.549 | INFO     | livecheck.main:get_props:269 - Processing mpv-shader/ssim-downscaler version 20240905
2025-02-17 17:15:11.549 | DEBUG    | livecheck.main:parse_url:152 - Parsed URI: ParseResult(scheme='https', netloc='gist.github.com', path='/igv/36508af3ffc84410fe39761d6969be10/archive/6998ff663a135376dbaeb6f038e944d806a9b9d9.zip', params='', query='', fragment='')
2025-02-17 17:15:11.549 | DEBUG    | livecheck.utils:get_content:139 - Fetching https://api.github.com/gists/36508af3ffc84410fe39761d6969be10
DEBUG:keyring.backend:Loading KWallet
DEBUG:keyring.backend:Loading SecretService
DEBUG:keyring.backend:Loading Windows
DEBUG:keyring.backend:Loading chainer
DEBUG:keyring.backend:Loading libsecret
DEBUG:keyring.backend:Loading macOS
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): api.github.com:443
DEBUG:urllib3.connectionpool:https://api.github.com:443 "GET /gists/36508af3ffc84410fe39761d6969be10 HTTP/1.1" 200 None
2025-02-17 17:15:11.974 | DEBUG    | livecheck.main:get_props:354 - Inserting mpv-shader/ssim-downscaler: 20240905 ->  : 38992bce7f9ff844f800820df0908692b65bb74a
2025-02-17 17:15:11.975 | DEBUG    | livecheck.main:do_main:452 - Incrementing revision to r1
2025-02-17 17:15:11.975 | DEBUG    | livecheck.main:do_main:454 - top_hash = 20240905-r1
2025-02-17 17:15:11.975 | DEBUG    | livecheck.main:do_main:456 - Comparing current ebuild version 20240905 with live version 20240905-r1
2025-02-17 17:15:11.975 | DEBUG    | livecheck.main:do_main:463 - Migrating from /usr/portage/local/tatsh-overlay/mpv-shader/ssim-downscaler/ssim-downscaler-20240905.ebuild to /usr/portage/local/tatsh-overlay/mpv-shader/ssim-downscaler/ssim-downscaler-20240905-r1.ebuild
mpv-shader/ssim-downscaler: 20240905 (6998ff663a135376dbaeb6f038e944d806a9b9d9) -> 20240905-r1 (38992bce7f9ff844f800820df0908692b65bb74a)
</pre>