### PR TITLE
fix: ignore releaseNum when normalizing DaVinci versions and return m…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ## [unreleased]
 
+- Ignore releaseNum when normalizing DaVinci versions and return major.minor
+
 ## [0.1.1]
 
 ## Changed

--- a/livecheck/special/davinci.py
+++ b/livecheck/special/davinci.py
@@ -16,4 +16,6 @@ def get_latest_davinci_package(pkg: str) -> str:
         return ''
 
     data = r.json()
+    if data['linux']['releaseNum'] == 0:
+        return f"{data['linux']['major']}.{data['linux']['minor']}"
     return f"{data['linux']['major']}.{data['linux']['minor']}.{data['linux']['releaseNum']}"

--- a/tests/special/test_davinci.py
+++ b/tests/special/test_davinci.py
@@ -11,11 +11,35 @@ if TYPE_CHECKING:
 
 def test_get_latest_davinci_package_success(mocker: MockerFixture) -> None:
     mock_response = mocker.Mock()
-    mock_response.json.return_value = {'linux': {'major': 18, 'minor': 5, 'releaseNum': 1}}
+    mock_response.json.return_value = {
+        'linux': {
+            'releaseId': 'a6e2bbb59c294d728d131fa21d18676b',
+            'downloadId': '407110f9045e410996bb9ff3ad6956d5',
+            'major': 18,
+            'minor': 5,
+            'releaseNum': 1,
+            'build': 49
+        }
+    }
     mock_get_content = mocker.patch('livecheck.special.davinci.get_content',
                                     return_value=mock_response)
     result = get_latest_davinci_package('davinci')
     assert result == '18.5.1'
+    mock_response.json.return_value = {
+        'linux': {
+            'releaseId': 'a6e2bbb59c294d728d131fa21d18676b',
+            'downloadId': '407110f9045e410996bb9ff3ad6956d5',
+            'major': 20,
+            'minor': 0,
+            'releaseNum': 0,
+            'build': 49
+        }
+    }
+    mock_get_content = mocker.patch('livecheck.special.davinci.get_content',
+                                    return_value=mock_response)
+    result = get_latest_davinci_package('davinci')
+    assert result == '20.0'
+
     mock_get_content.assert_called_once_with(
         'https://www.blackmagicdesign.com/api/support/latest-stable-version/davinci/linux')
 
@@ -36,7 +60,15 @@ def test_get_latest_davinci_package_missing_linux_key(mocker: MockerFixture) -> 
 
 def test_get_latest_davinci_package_partial_linux_data(mocker: MockerFixture) -> None:
     mock_response = mocker.Mock()
-    mock_response.json.return_value = {'linux': {'major': 18, 'minor': 5}}
+    mock_response.json.return_value = {
+        'linux': {
+            'releaseId': 'a6e2bbb59c294d728d131fa21d18676b',
+            'downloadId': '407110f9045e410996bb9ff3ad6956d5',
+            'major': 18,
+            'minor': 1,
+            'build': 49
+        }
+    }
     mocker.patch('livecheck.special.davinci.get_content', return_value=mock_response)
     with pytest.raises(KeyError):
         get_latest_davinci_package('davinci')


### PR DESCRIPTION
…ajor.minor