### PR TITLE
Get the real sha from GitHub for a version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ## [unreleased]
 
 - Ignore releaseNum when normalizing DaVinci versions and return major.minor
+- Fix the real sha from GitHub for a version
 
 ## [0.1.1]
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ action directory there can be several scripts that are executed in order of name
 - `no_auto_update` - boolean - Do not allow auto-updating of this package.
 - `nodejs_packages` - boolean - Download nodejs node_modules.
 - `nodejs_path` - path - Where is 'package.json' located (need nodejs_packages).
+- `sha_source`- string - Url to get the sha value.
 - `stable_version`- string - Regular expression to determine if it is a stable version.
 - `sync_version` - string - Category and ebuild with version to sync.
 - `transformation_function` - string - Function to use to transform the version string.

--- a/livecheck/special/github.py
+++ b/livecheck/special/github.py
@@ -47,11 +47,8 @@ def get_latest_github_package(url: str, ebuild: str,
                               settings: LivecheckSettings) -> tuple[str, str]:
     """Get the latest version of a Github package."""
     domain, owner, repo = extract_owner_repo(url)
-    if not owner or not repo:
-        return '', ''
-
     url = GITHUB_DOWNLOAD_URL % (domain)
-    if not (r := get_content(url)):
+    if not owner or not repo or not (r := get_content(url)):
         return '', ''
 
     try:

--- a/livecheck/special/github.py
+++ b/livecheck/special/github.py
@@ -66,6 +66,8 @@ def get_latest_github_package(url: str, ebuild: str,
         url = GITHUB_DATE_URL % (owner, repo, last_version['id'])
         if not (r := get_content(url)):
             return last_version['version'], ''
+        if not (r := get_content(r.json()['object']['url'])):
+            return last_version['version'], ''
         return last_version['version'], r.json()['object']['sha']
     return '', ''
 

--- a/tests/special/test_github.py
+++ b/tests/special/test_github.py
@@ -174,6 +174,21 @@ def test_get_latest_github_package_no_response(mocker: MockerFixture) -> None:
     assert result == ('', '')
 
 
+def test_get_latest_github_package_xml_parse_error(mocker: MockerFixture) -> None:
+    # Patch extract_owner_repo to return valid values
+    mocker.patch('livecheck.special.github.extract_owner_repo',
+                 return_value=('https://github.com/owner/repo', 'owner', 'repo'))
+    # Patch get_content to return a mock response with any text
+    mock_response = mocker.Mock()
+    mock_response.text = '<invalid><xml>'
+    mocker.patch('livecheck.special.github.get_content', return_value=mock_response)
+    # Patch ET.fromstring to raise ParseError
+    mocker.patch('livecheck.special.github.ET.fromstring', side_effect=ET.ParseError)
+    result = get_latest_github_package('https://github.com/owner/repo', 'cat/repo-1.0.0.ebuild',
+                                       mocker.Mock())
+    assert result == ('', '')
+
+
 def test_get_latest_github_package_no_response_2(mocker: MockerFixture) -> None:
     xml = '<?xml version="1.0" encoding="UTF-8"?><feed xmlns="http://www.w3.org/2005/Atom"></feed>'
     mocker.patch('livecheck.special.github.get_content', side_effect=[mocker.Mock(text=xml), None])

--- a/tests/special/test_github.py
+++ b/tests/special/test_github.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from defusedxml import ElementTree as ET  # noqa: N817
 from livecheck.special.github import (
     extract_owner_repo,
     get_branch,


### PR DESCRIPTION
To correctly obtain the SHA of a version on GitHub, you must first download the URL that defines the tag.

Example
https://api.github.com/repos/composer/composer/git/refs/tags/2.8.10
<pre>
{
  "ref": "refs/tags/2.8.10",
  "node_id": "MDM6UmVmMTg2NDM2MzpyZWZzL3RhZ3MvMi44LjEw",
  "url": "https://api.github.com/repos/composer/composer/git/refs/tags/2.8.10",
  "object": {
    "sha": "adf002c8f53b49352c044f53b30db601398353fb",
    "type": "tag",
    "url": "https://api.github.com/repos/composer/composer/git/tags/adf002c8f53b49352c044f53b30db601398353fb"
  }
}
</pre>

https://api.github.com/repos/composer/composer/git/tags/adf002c8f53b49352c044f53b30db601398353fb
<pre>
{
  "node_id": "TA_kwDOABxyq9oAKGFkZjAwMmM4ZjUzYjQ5MzUyYzA0NGY1M2IzMGRiNjAxMzk4MzUzZmI",
  "sha": "adf002c8f53b49352c044f53b30db601398353fb",
  "url": "https://api.github.com/repos/composer/composer/git/tags/adf002c8f53b49352c044f53b30db601398353fb",
  "tagger": {
    "name": "Jordi Boggiano",
    "email": "j.boggiano@seld.be",
    "date": "2025-07-10T17:08:33Z"
  },
  "object": {
    "sha": "53834f587d7ab2527eb237459d7b94d1fb9d4c5a",
    "type": "commit",
    "url": "https://api.github.com/repos/composer/composer/git/commits/53834f587d7ab2527eb237459d7b94d1fb9d4c5a"
  },
  "tag": "2.8.10",
  "message": "Release 2.8.10\n",
  "verification": {
    "verified": false,
    "reason": "unsigned",
    "signature": null,
    "payload": null,
    "verified_at": null
  }
}
</pre>

The real SHA is 53834f587d7ab2527eb237459d7b94d1fb9d4c5a and not adf002c8f53b49352c044f53b30db601398353fb