### PR TITLE
remove build from version

### DIFF
--- a/livecheck/utils/portage.py
+++ b/livecheck/utils/portage.py
@@ -240,6 +240,8 @@ def normalize_version(ver: str) -> str:
     suf = re.sub(r'[-_\. ]', '', suf)
     if suf.isdigit():
         return f'{main}.{suf}'
+    if suf.startswith('build'):
+        return f'{main}'
 
     if m := re.match(r'^([A-Za-z]+)([0-9]+)?', suf):
         letters, digits = m.groups()

--- a/tests/utils/test_portage.py
+++ b/tests/utils/test_portage.py
@@ -83,6 +83,7 @@ if TYPE_CHECKING:
     ('0.0.8b2', '0.0.8_beta2'),
     ('0.0.8a5', '0.0.8_alpha5'),
     ('0.1.8b0', '0.1.8_beta'),
+    ('1.4.1-build.2', '1.4.1'),
 ])
 def test_sanitize_version(version: str, expected: str) -> None:
     assert sanitize_version(version) == expected


### PR DESCRIPTION
A build is not a new version, it is simply a recompilation of the same code. This generates false new versions.