### PR TITLE
Prevent false version updates when upstream publishes unrelated packages

### DIFF
--- a/livecheck/special/bitbucket.py
+++ b/livecheck/special/bitbucket.py
@@ -1,6 +1,7 @@
 """Bitbucket functions."""
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
@@ -21,6 +22,17 @@ BITBUCKET_TAG_URL = 'https://api.bitbucket.org/2.0/repositories/%s/%s/refs/tags'
 BITBUCKET_DOWNLOAD_URL = 'https://api.bitbucket.org/2.0/repositories/%s/%s/downloads'
 BITBUCKET_METADATA = 'bitbucket'
 MAX_ITERATIONS = 4
+
+
+def _bitbucket_version_reference(url: str) -> str:
+    parts = [part for part in urlparse(url).path.split('/') if part]
+    for i, part in enumerate(parts):
+        if part == 'get' and i + 1 < len(parts):
+            reference = parts[i + 1]
+            if ext := get_archive_extension(reference):
+                return reference[:-len(ext)]
+            return reference
+    return Path(urlparse(url).path).name
 
 
 def extract_workspace_and_repository(url: str) -> tuple[str, str]:
@@ -54,6 +66,7 @@ async def get_latest_bitbucket_package(url: str, cpv: str,
     tuple[str, str]
         Latest version string and commit hash, or empty strings if unavailable.
     """
+    version_reference = _bitbucket_version_reference(url)
     workspace, repository = extract_workspace_and_repository(url)
 
     url = BITBUCKET_TAG_URL % (workspace, repository)
@@ -84,7 +97,11 @@ async def get_latest_bitbucket_package(url: str, cpv: str,
         url = data.get('next')
         iteration_count += 1
 
-    if last_version := get_last_version(results, repository, cpv, settings):
+    if last_version := get_last_version(results,
+                                        repository,
+                                        cpv,
+                                        settings,
+                                        version_reference=version_reference):
         return last_version['version'], last_version['id']
 
     return '', ''

--- a/livecheck/special/directory.py
+++ b/livecheck/special/directory.py
@@ -52,7 +52,11 @@ async def get_latest_directory_package(url: str, ebuild: str,
                 if name.startswith(archive):
                     results.append({'tag': name, 'url': file})
 
-        if last_version := get_last_version(results, archive, ebuild, settings):
+        if last_version := get_last_version(results,
+                                            archive,
+                                            ebuild,
+                                            settings,
+                                            version_reference=Path(urlparse(url).path).name):
             return last_version['version'], last_version['url']
 
     return '', ''

--- a/livecheck/special/github.py
+++ b/livecheck/special/github.py
@@ -100,11 +100,8 @@ async def get_latest_github_package(url: str, ebuild: str,
         if tag := (tag_id.split('/')[-1] if tag_id and '/' in tag_id else ''):
             results.append({'tag': tag, 'id': tag})
 
-    if not (last_version := get_last_version(results,
-                                             repo,
-                                             ebuild,
-                                             settings,
-                                             version_reference=version_reference)):
+    if not (last_version := get_last_version(
+            results, repo, ebuild, settings, version_reference=version_reference)):
         return '', ''
 
     url = GITHUB_DATE_URL % (owner, repo, last_version['id'])

--- a/livecheck/special/github.py
+++ b/livecheck/special/github.py
@@ -11,6 +11,8 @@ from livecheck.constants import RSS_NS
 from livecheck.utils import get_content, is_sha
 from livecheck.utils.portage import catpkg_catpkgsplit, get_last_version
 
+from .utils import get_archive_extension
+
 if TYPE_CHECKING:
     from livecheck.settings_model import LivecheckSettings
 
@@ -22,6 +24,23 @@ GITHUB_DOWNLOAD_URL = '%s/tags.atom'
 GITHUB_COMMIT_URL = 'https://api.github.com/repos/%s/%s/branches/%s'
 GITHUB_DATE_URL = 'https://api.github.com/repos/%s/%s/git/refs/tags/%s'
 GITHUB_METADATA = 'github'
+
+
+def _github_tag_reference(url: str) -> str:
+    parsed = urlparse(url)
+    parts = [part for part in parsed.path.split('/') if part]
+    for i, part in enumerate(parts):
+        if part == 'releases' and parts[i:i + 2] == ['releases', 'download']:
+            return parts[i + 2] if i + 2 < len(parts) else ''
+        if part == 'archive' and i + 1 < len(parts):
+            archive_ref = '/'.join(parts[i + 1:])
+            archive_ref = re.sub(r'^(?:refs/)?tags/', '', archive_ref)
+            if ext := get_archive_extension(archive_ref):
+                return archive_ref[:-len(ext)]
+            return archive_ref
+    if parsed.netloc == 'codeload.github.com' and len(parts) >= 4:  # noqa: PLR2004
+        return re.sub(r'^(?:refs/)?tags/', '', '/'.join(parts[3:]))
+    return ''
 
 
 def extract_owner_repo(url: str) -> tuple[str, str, str]:
@@ -62,6 +81,7 @@ async def get_latest_github_package(url: str, ebuild: str,
     tuple[str, str]
         Latest tag version and resolved commit SHA, or empty strings if unavailable.
     """
+    version_reference = _github_tag_reference(url)
     domain, owner, repo = extract_owner_repo(url)
     url = GITHUB_DOWNLOAD_URL % (domain)
     if not owner or not repo or not (r := await get_content(url)):
@@ -80,7 +100,11 @@ async def get_latest_github_package(url: str, ebuild: str,
         if tag := (tag_id.split('/')[-1] if tag_id and '/' in tag_id else ''):
             results.append({'tag': tag, 'id': tag})
 
-    if not (last_version := get_last_version(results, repo, ebuild, settings)):
+    if not (last_version := get_last_version(results,
+                                             repo,
+                                             ebuild,
+                                             settings,
+                                             version_reference=version_reference)):
         return '', ''
 
     url = GITHUB_DATE_URL % (owner, repo, last_version['id'])

--- a/livecheck/special/gitlab.py
+++ b/livecheck/special/gitlab.py
@@ -31,6 +31,14 @@ GITLAB_HOSTNAMES: Mapping[str, str] = {
 VERSIONS = 40
 
 
+def _gitlab_version_reference(url: str) -> str:
+    parts = [part for part in urlparse(url).path.split('/') if part]
+    for i, part in enumerate(parts):
+        if part == 'archive' and i + 1 < len(parts) and i > 0 and parts[i - 1] == '-':
+            return parts[i + 1]
+    return ''
+
+
 def extract_domain_and_namespace(url: str) -> tuple[str, str, str]:
     parsed = urlparse(url)
     if not re.search(r'^gitlab\.(com$|.*\.)', parsed.netloc):
@@ -65,6 +73,7 @@ async def get_latest_gitlab_package(url: str, ebuild: str,
     tuple[str, str]
         Latest tag version and commit id, or empty strings if unavailable.
     """
+    version_reference = _gitlab_version_reference(url)
     domain, path_with_namespace, repo = extract_domain_and_namespace(url)
     encoded_path = quote(path_with_namespace, safe='')
 
@@ -78,7 +87,11 @@ async def get_latest_gitlab_package(url: str, ebuild: str,
         'id': tag.get('commit', {}).get('id', '')
     } for tag in r.json()]
 
-    if last_version := get_last_version(results, repo, ebuild, settings):
+    if last_version := get_last_version(results,
+                                        repo,
+                                        ebuild,
+                                        settings,
+                                        version_reference=version_reference):
         return last_version['version'], last_version['id']
 
     return '', ''

--- a/livecheck/special/pypi.py
+++ b/livecheck/special/pypi.py
@@ -1,6 +1,7 @@
 """PyPI functions."""
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 import re
@@ -69,7 +70,11 @@ async def get_latest_pypi_package2(project_name: str, src_uri: str, ebuild: str,
         for release, item in r.json().get('releases', {}).items():
             results.extend([{'tag': release, 'url': get_url(ext, item)}])
 
-        if last_version := get_last_version(results, '', ebuild, settings):
+        if last_version := get_last_version(results,
+                                            '',
+                                            ebuild,
+                                            settings,
+                                            version_reference=Path(urlparse(src_uri).path).name):
             return last_version['version'], last_version['url']
 
     return '', ''

--- a/livecheck/special/sourceforge.py
+++ b/livecheck/special/sourceforge.py
@@ -22,6 +22,13 @@ SOURCEFORGE_DOWNLOAD_URL = 'https://sourceforge.net/projects/%s/rss'
 SOURCEFORGE_METADATA = 'sourceforge'
 
 
+def _sourceforge_version_reference(url: str) -> str:
+    parts = [part for part in urlparse(url).path.split('/') if part]
+    if parts and parts[-1] == 'download':
+        return parts[-2] if len(parts) > 1 else ''
+    return Path(urlparse(url).path).name
+
+
 def extract_repository(url: str) -> str:
     parsed = urlparse(url)
     n = parsed.netloc
@@ -48,11 +55,16 @@ async def get_latest_sourceforge_package(src_uri: str, ebuild: str,
         Latest release filename version from the RSS feed, or an empty string if none.
     """
     repository = extract_repository(src_uri)
-    return await get_latest_sourceforge_package2(repository, ebuild, settings)
+    return await get_latest_sourceforge_package2(repository,
+                                                ebuild,
+                                                settings,
+                                                version_reference=_sourceforge_version_reference(
+                                                    src_uri))
 
 
 async def get_latest_sourceforge_package2(repository: str, ebuild: str,
-                                          settings: LivecheckSettings) -> str:
+                                          settings: LivecheckSettings,
+                                          version_reference: str = '') -> str:
     url = SOURCEFORGE_DOWNLOAD_URL % (repository)
 
     if not (r := await get_content(url)):
@@ -65,7 +77,11 @@ async def get_latest_sourceforge_package2(repository: str, ebuild: str,
         if version and get_archive_extension(version):
             results.append({'tag': version})
 
-    if last_version := get_last_version(results, repository, ebuild, settings):
+    if last_version := get_last_version(results,
+                                        repository,
+                                        ebuild,
+                                        settings,
+                                        version_reference=version_reference):
         return last_version['version']
 
     return ''

--- a/livecheck/special/sourceforge.py
+++ b/livecheck/special/sourceforge.py
@@ -55,14 +55,12 @@ async def get_latest_sourceforge_package(src_uri: str, ebuild: str,
         Latest release filename version from the RSS feed, or an empty string if none.
     """
     repository = extract_repository(src_uri)
-    return await get_latest_sourceforge_package2(repository,
-                                                ebuild,
-                                                settings,
-                                                version_reference=_sourceforge_version_reference(
-                                                    src_uri))
+    return await get_latest_sourceforge_package2(
+        repository, ebuild, settings, version_reference=_sourceforge_version_reference(src_uri))
 
 
-async def get_latest_sourceforge_package2(repository: str, ebuild: str,
+async def get_latest_sourceforge_package2(repository: str,
+                                          ebuild: str,
                                           settings: LivecheckSettings,
                                           version_reference: str = '') -> str:
     url = SOURCEFORGE_DOWNLOAD_URL % (repository)

--- a/livecheck/special/sourcehut.py
+++ b/livecheck/special/sourcehut.py
@@ -10,6 +10,8 @@ from defusedxml import ElementTree as ET  # noqa: N817
 from livecheck.utils import get_content, is_sha
 from livecheck.utils.portage import catpkg_catpkgsplit, get_last_version
 
+from .utils import get_archive_extension
+
 if TYPE_CHECKING:
     from livecheck.settings_model import LivecheckSettings
 
@@ -19,6 +21,17 @@ __all__ = ('SOURCEHUT_METADATA', 'get_latest_sourcehut', 'get_latest_sourcehut_c
 SOURCEHUT_DOWNLOAD_URL = 'https://%s/%s/%s/refs/rss.xml'
 SOURCEHUT_COMMIT_URL = 'https://%s/%s/%s/log/%s/rss.xml'
 SOURCEHUT_METADATA = 'sourcehut'
+
+
+def _sourcehut_version_reference(url: str) -> str:
+    parts = [part for part in urlparse(url).path.split('/') if part]
+    for i, part in enumerate(parts):
+        if part == 'archive' and i + 1 < len(parts):
+            reference = parts[i + 1]
+            if ext := get_archive_extension(reference):
+                return reference[:-len(ext)]
+            return reference
+    return ''
 
 
 def extract_owner_repo(url: str) -> tuple[str, str, str]:
@@ -50,6 +63,7 @@ async def get_latest_sourcehut_package(url: str, ebuild: str, settings: Livechec
     if not owner or not repo:
         return ''
 
+    version_reference = _sourcehut_version_reference(url)
     url = SOURCEHUT_DOWNLOAD_URL % (domain, owner, repo)
 
     if not (r := await get_content(url)):
@@ -61,7 +75,11 @@ async def get_latest_sourcehut_package(url: str, ebuild: str, settings: Livechec
         if version := guid.text.split('/')[-1] if guid is not None and guid.text else '':
             results.append({'tag': version})
 
-    if last_version := get_last_version(results, repo, ebuild, settings):
+    if last_version := get_last_version(results,
+                                        repo,
+                                        ebuild,
+                                        settings,
+                                        version_reference=version_reference):
         return last_version['version']
     return ''
 

--- a/livecheck/utils/portage.py
+++ b/livecheck/utils/portage.py
@@ -5,6 +5,7 @@ from functools import cache
 from itertools import chain
 from pathlib import Path
 from typing import TYPE_CHECKING
+from urllib.parse import urlparse
 import logging
 import re
 
@@ -503,8 +504,34 @@ def unpack_ebuild(ebuild_path: str) -> str:
     return ''
 
 
-def get_last_version(results: Collection[Mapping[str, str]], repo: str, ebuild: str,
-                     settings: LivecheckSettings) -> dict[str, str]:
+def _candidate_version_reference(result: Mapping[str, str], tag: str) -> str:
+    if url := result.get('url', ''):
+        return Path(urlparse(url).path).name or tag
+    return tag
+
+
+def _candidate_version_from_reference(candidate: str, reference: str,
+                                      ebuild_version: str) -> str | None:
+    if not reference:
+        return ''
+
+    reference_version = re.sub(r'-r\d+$', '', ebuild_version)
+    if not (match := re.search(re.escape(reference_version), reference)):
+        return ''
+
+    prefix = reference[:match.start()]
+    suffix = reference[match.end():]
+    if not candidate.startswith(prefix) or not candidate.endswith(suffix):
+        return None
+    end = -len(suffix) if suffix else None
+    return sanitize_version(candidate[len(prefix):end])
+
+
+def get_last_version(results: Collection[Mapping[str, str]],
+                     repo: str,
+                     ebuild: str,
+                     settings: LivecheckSettings,
+                     version_reference: str = '') -> dict[str, str]:
     """
     Get the latest version from the results.
 
@@ -518,6 +545,8 @@ def get_last_version(results: Collection[Mapping[str, str]], repo: str, ebuild: 
         Ebuild atom string.
     settings : LivecheckSettings
         Livecheck settings instance.
+    version_reference : str
+        Current upstream tag or filename whose versioned pattern candidates must match.
 
     Returns
     -------
@@ -543,6 +572,15 @@ def get_last_version(results: Collection[Mapping[str, str]], repo: str, ebuild: 
             log.debug('Convert Tag: %s -> %s', tag, version)
         if not version:
             continue
+        reference_version = _candidate_version_from_reference(_candidate_version_reference(result,
+                                                                                           tag),
+                                                              version_reference,
+                                                              ebuild_version)
+        if reference_version is None:
+            log.debug('Skip tag with mismatched version pattern: %s', tag)
+            continue
+        if reference_version:
+            version = reference_version
         # Skip extraneous version without dots, e.g. Post120ToMaster.
         if ebuild_version.count('.') > 1 and version.count('.') == 0:
             log.debug('Skip version without dots: %s', version)

--- a/livecheck/utils/portage.py
+++ b/livecheck/utils/portage.py
@@ -572,10 +572,8 @@ def get_last_version(results: Collection[Mapping[str, str]],
             log.debug('Convert Tag: %s -> %s', tag, version)
         if not version:
             continue
-        reference_version = _candidate_version_from_reference(_candidate_version_reference(result,
-                                                                                           tag),
-                                                              version_reference,
-                                                              ebuild_version)
+        reference_version = _candidate_version_from_reference(
+            _candidate_version_reference(result, tag), version_reference, ebuild_version)
         if reference_version is None:
             log.debug('Skip tag with mismatched version pattern: %s', tag)
             continue

--- a/tests/special/test_github.py
+++ b/tests/special/test_github.py
@@ -210,6 +210,70 @@ async def test_get_latest_github_package_no_response_2(mocker: MockerFixture) ->
     assert result == ('version', '')
 
 
+@pytest.mark.asyncio
+async def test_get_latest_github_package_uses_release_download_tag(mocker: MockerFixture) -> None:
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+    <feed xmlns="http://www.w3.org/2005/Atom">
+        <entry>
+            <id>https://github.com/grafana/loki/releases/tag/helm-loki-7.0.0</id>
+        </entry>
+        <entry>
+            <id>https://github.com/grafana/loki/releases/tag/v3.7.2</id>
+        </entry>
+    </feed>
+    """
+    mocker.patch('livecheck.special.github.extract_owner_repo',
+                 return_value=('https://github.com/grafana/loki', 'grafana', 'loki'))
+    mocker.patch('livecheck.special.github.get_content',
+                 side_effect=[mocker.Mock(text=xml), None])
+    settings = mocker.Mock()
+    settings.regex_version = {}
+    settings.restrict_version = {}
+    settings.restrict_version_process = ''
+    settings.stable_version = {}
+    settings.transformations = {}
+    settings.is_devel = lambda _: False
+
+    result = await get_latest_github_package(
+        'https://github.com/grafana/loki/releases/download/v3.7.1/loki-3.7.1.x86_64.rpm',
+        'app-metrics/loki-3.7.1',
+        settings)
+
+    assert result == ('3.7.2', '')
+
+
+@pytest.mark.asyncio
+async def test_get_latest_github_package_uses_archive_tag(mocker: MockerFixture) -> None:
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+    <feed xmlns="http://www.w3.org/2005/Atom">
+        <entry>
+            <id>https://github.com/grafana/loki/releases/tag/helm-loki-7.0.0</id>
+        </entry>
+        <entry>
+            <id>https://github.com/grafana/loki/releases/tag/v3.7.2</id>
+        </entry>
+    </feed>
+    """
+    mocker.patch('livecheck.special.github.extract_owner_repo',
+                 return_value=('https://github.com/grafana/loki', 'grafana', 'loki'))
+    mocker.patch('livecheck.special.github.get_content',
+                 side_effect=[mocker.Mock(text=xml), None])
+    settings = mocker.Mock()
+    settings.regex_version = {}
+    settings.restrict_version = {}
+    settings.restrict_version_process = ''
+    settings.stable_version = {}
+    settings.transformations = {}
+    settings.is_devel = lambda _: False
+
+    result = await get_latest_github_package(
+        'https://github.com/grafana/loki/archive/v3.7.1.tar.gz',
+        'app-admin/loki-3.7.1',
+        settings)
+
+    assert result == ('3.7.2', '')
+
+
 @pytest.mark.parametrize(
     ('url', 'branch', 'owner', 'repo', 'commit_sha', 'commit_date', 'expected'),
     [

--- a/tests/special/test_github.py
+++ b/tests/special/test_github.py
@@ -224,8 +224,7 @@ async def test_get_latest_github_package_uses_release_download_tag(mocker: Mocke
     """
     mocker.patch('livecheck.special.github.extract_owner_repo',
                  return_value=('https://github.com/grafana/loki', 'grafana', 'loki'))
-    mocker.patch('livecheck.special.github.get_content',
-                 side_effect=[mocker.Mock(text=xml), None])
+    mocker.patch('livecheck.special.github.get_content', side_effect=[mocker.Mock(text=xml), None])
     settings = mocker.Mock()
     settings.regex_version = {}
     settings.restrict_version = {}
@@ -236,8 +235,7 @@ async def test_get_latest_github_package_uses_release_download_tag(mocker: Mocke
 
     result = await get_latest_github_package(
         'https://github.com/grafana/loki/releases/download/v3.7.1/loki-3.7.1.x86_64.rpm',
-        'app-metrics/loki-3.7.1',
-        settings)
+        'app-metrics/loki-3.7.1', settings)
 
     assert result == ('3.7.2', '')
 
@@ -256,8 +254,7 @@ async def test_get_latest_github_package_uses_archive_tag(mocker: MockerFixture)
     """
     mocker.patch('livecheck.special.github.extract_owner_repo',
                  return_value=('https://github.com/grafana/loki', 'grafana', 'loki'))
-    mocker.patch('livecheck.special.github.get_content',
-                 side_effect=[mocker.Mock(text=xml), None])
+    mocker.patch('livecheck.special.github.get_content', side_effect=[mocker.Mock(text=xml), None])
     settings = mocker.Mock()
     settings.regex_version = {}
     settings.restrict_version = {}
@@ -267,9 +264,7 @@ async def test_get_latest_github_package_uses_archive_tag(mocker: MockerFixture)
     settings.is_devel = lambda _: False
 
     result = await get_latest_github_package(
-        'https://github.com/grafana/loki/archive/v3.7.1.tar.gz',
-        'app-admin/loki-3.7.1',
-        settings)
+        'https://github.com/grafana/loki/archive/v3.7.1.tar.gz', 'app-admin/loki-3.7.1', settings)
 
     assert result == ('3.7.2', '')
 

--- a/tests/utils/test_portage.py
+++ b/tests/utils/test_portage.py
@@ -820,6 +820,54 @@ def test_get_last_version_catpkg_catpkgsplit_raises_value_error(mocker: MockerFi
     assert result == {}
 
 
+def test_get_last_version_rejects_mismatched_version_reference(mocker: MockerFixture) -> None:
+    dummy_settings = mocker.Mock()
+    dummy_settings.regex_version = {}
+    dummy_settings.restrict_version = {}
+    dummy_settings.restrict_version_process = ''
+    dummy_settings.stable_version = {}
+    dummy_settings.transformations = {}
+    dummy_settings.is_devel = lambda _: False
+
+    result = get_last_version([{
+        'tag': 'helm-loki-7.0.0'
+    }, {
+        'tag': 'v3.7.2'
+    }],
+                              'loki',
+                              'app-metrics/loki-3.7.1',
+                              dummy_settings,
+                              version_reference='v3.7.1')
+
+    assert result['version'] == '3.7.2'
+    assert result['tag'] == 'v3.7.2'
+
+
+def test_get_last_version_rejects_mismatched_file_reference(mocker: MockerFixture) -> None:
+    dummy_settings = mocker.Mock()
+    dummy_settings.regex_version = {}
+    dummy_settings.restrict_version = {}
+    dummy_settings.restrict_version_process = ''
+    dummy_settings.stable_version = {}
+    dummy_settings.transformations = {}
+    dummy_settings.is_devel = lambda _: False
+
+    result = get_last_version([{
+        'tag': 'helm-loki-7.0.0.x86_64.rpm',
+        'url': 'https://example.com/helm-loki-7.0.0.x86_64.rpm'
+    }, {
+        'tag': 'loki-3.7.2.x86_64.rpm',
+        'url': 'https://example.com/loki-3.7.2.x86_64.rpm'
+    }],
+                              'loki',
+                              'app-admin/loki-3.7.1',
+                              dummy_settings,
+                              version_reference='loki-3.7.1.x86_64.rpm')
+
+    assert result['version'] == '3.7.2'
+    assert result['tag'] == 'loki-3.7.2.x86_64.rpm'
+
+
 @pytest.mark.parametrize(
     ('ebuild_version', 'version', 'catpkg', 'settings_attrs', 'expected'),
     [


### PR DESCRIPTION
I checked with my overlay and runs fine
It solves this problem

<pre>
2026-04-27 19:09:49,792 | INFO     | livecheck.main:get_props:551 - Found 1 ebuild.
2026-04-27 19:09:49,792 | INFO     | livecheck.main:_check_one_package:413 - Processing: app-admin/loki | Version: 3.7.1
2026-04-27 19:09:49,792 | DEBUG    | livecheck.main:_check_one_package:476 - Trying SRC_URI for app-admin/loki: https://github.com/grafana/loki/archive/v3.7.1.tar.gz
2026-04-27 19:09:49,793 | DEBUG    | livecheck.main:parse_url:262 - Parsed URI: ParseResult(scheme='https', netloc='github.com', path='/grafana/loki/archive/v3.7.1.tar.gz', params='', query='', fragment='')
2026-04-27 19:09:49,793 | DEBUG    | livecheck.main:parse_url:267 - Matched handler: github for app-admin/loki-3.7.1.
2026-04-27 19:09:49,793 | DEBUG    | livecheck.utils.requests:get_content:145 - Fetching https://github.com/grafana/loki/tags.atom
2026-04-27 19:09:49,794 | DEBUG    | niquests_cache.session:_log_backend:218 - Using backend `niquests_cache.backends.sqlite.SQLiteBackend`. Path: /home/fran/.cache/livecheck/http.sqlite
2026-04-27 19:09:49,801 | DEBUG    | urllib3_future._async.connectionpool:_new_conn:2169 - Starting new HTTPS connection (1): github.com:443
2026-04-27 19:09:50,246 | DEBUG    | urllib3_future._async.connectionpool:_make_request:1453 - https://github.com:443 "GET /grafana/loki/tags.atom HTTP/2.0" 200 7183
2026-04-27 19:09:50,246 | DEBUG    | livecheck.utils.portage:get_last_version:527 - Result count: 10
2026-04-27 19:09:50,247 | DEBUG    | livecheck.utils.portage:get_last_version:543 - Convert Tag: helm-loki-7.0.0 -> 7.0.0
2026-04-27 19:09:50,247 | DEBUG    | livecheck.utils.portage:get_last_version:543 - Convert Tag: v0.0.1-test -> 0.0.1_beta
2026-04-27 19:09:50,247 | DEBUG    | livecheck.utils.portage:get_last_version:543 - Convert Tag: v0.10.1 -> 0.10.1
2026-04-27 19:09:50,247 | DEBUG    | livecheck.utils.portage:get_last_version:543 - Convert Tag: v3.6.10 -> 3.6.10
2026-04-27 19:09:50,247 | DEBUG    | livecheck.utils.portage:get_last_version:543 - Convert Tag: v3.6.9 -> 3.6.9
2026-04-27 19:09:50,247 | DEBUG    | livecheck.utils.portage:get_last_version:543 - Convert Tag: v3.7.1 -> 3.7.1
2026-04-27 19:09:50,247 | DEBUG    | livecheck.utils.portage:get_last_version:543 - Convert Tag: v3.7.0 -> 3.7.0
2026-04-27 19:09:50,247 | DEBUG    | livecheck.utils.portage:get_last_version:543 - Convert Tag: v3.6.8 -> 3.6.8
2026-04-27 19:09:50,247 | DEBUG    | livecheck.utils.portage:get_last_version:543 - Convert Tag: v0.10.0 -> 0.10.0
2026-04-27 19:09:50,247 | DEBUG    | livecheck.utils.portage:get_last_version:543 - Convert Tag: v3.5.12 -> 3.5.12
2026-04-27 19:09:50,247 | DEBUG    | livecheck.utils.requests:get_content:145 - Fetching https://api.github.com/repos/grafana/loki/git/refs/tags/helm-loki-7.0.0
2026-04-27 19:09:50,248 | DEBUG    | niquests_cache.session:_log_backend:218 - Using backend `niquests_cache.backends.sqlite.SQLiteBackend`. Path: /home/fran/.cache/livecheck/http.sqlite
2026-04-27 19:09:50,310 | DEBUG    | urllib3_future._async.connectionpool:_new_conn:2169 - Starting new HTTPS connection (1): api.github.com:443
2026-04-27 19:09:50,760 | DEBUG    | urllib3_future._async.connectionpool:_make_request:1453 - https://api.github.com:443 "GET /repos/grafana/loki/git/refs/tags/helm-loki-7.0.0 HTTP/2.0" 200 None
2026-04-27 19:09:50,761 | DEBUG    | livecheck.main:_check_one_package:506 - Inserting app-admin/loki: 3.7.1 -> 7.0.0 : 
2026-04-27 19:09:50,761 | INFO     | livecheck.main:_bounded:564 - Progress: 1/1 packages checked.
2026-04-27 19:09:50,761 | DEBUG    | livecheck.main:do_main:719 - top_hash = 7.0.0
2026-04-27 19:09:50,761 | DEBUG    | livecheck.main:do_main:724 - Comparing current ebuild version 3.7.1 with live version 7.0.0.
2026-04-27 19:09:50,761 | DEBUG    | livecheck.main:do_main:731 - Migrating from /usr/portage/local/inode64/app-admin/loki/loki-3.7.1.ebuild to /usr/portage/local/inode64/app-admin/loki/loki-7.0.0.ebuild.
2026-04-27 19:09:50,761 | INFO     | livecheck.main:do_main:735 - app-admin/loki: 3.7.1 -> 7.0.0
</pre>

After

<pre>
2026-04-27 20:46:46,639 | INFO     | livecheck.main:_check_one_package:413 - Processing: app-admin/loki | Version: 3.7.1
2026-04-27 20:46:46,640 | DEBUG    | livecheck.main:_check_one_package:476 - Trying SRC_URI for app-admin/loki: https://github.com/grafana/loki/archive/v3.7.1.tar.gz
2026-04-27 20:46:46,640 | DEBUG    | livecheck.main:parse_url:262 - Parsed URI: ParseResult(scheme='https', netloc='github.com', path='/grafana/loki/archive/v3.7.1.tar.gz', params='', query='', fragment='')
2026-04-27 20:46:46,640 | DEBUG    | livecheck.main:parse_url:267 - Matched handler: github for app-admin/loki-3.7.1.
2026-04-27 20:46:46,641 | DEBUG    | livecheck.utils.requests:get_content:145 - Fetching https://github.com/grafana/loki/tags.atom
2026-04-27 20:46:46,642 | DEBUG    | niquests_cache.session:_log_backend:218 - Using backend `niquests_cache.backends.sqlite.SQLiteBackend`. Path: /home/fran/.cache/livecheck/http.sqlite
2026-04-27 20:46:46,650 | DEBUG    | urllib3_future._async.connectionpool:_new_conn:2169 - Starting new HTTPS connection (1): github.com:443
2026-04-27 20:46:46,793 | DEBUG    | urllib3_future._async.connectionpool:_make_request:1453 - https://github.com:443 "GET /grafana/loki/tags.atom HTTP/2.0" 200 7183
2026-04-27 20:46:46,794 | DEBUG    | livecheck.utils.portage:get_last_version:556 - Result count: 10
2026-04-27 20:46:46,795 | DEBUG    | livecheck.utils.portage:get_last_version:572 - Convert Tag: helm-loki-7.0.0 -> 7.0.0
2026-04-27 20:46:46,795 | DEBUG    | livecheck.utils.portage:get_last_version:580 - Skip tag with mismatched version pattern: helm-loki-7.0.0
2026-04-27 20:46:46,795 | DEBUG    | livecheck.utils.portage:get_last_version:572 - Convert Tag: v0.0.1-test -> 0.0.1_beta
2026-04-27 20:46:46,795 | DEBUG    | livecheck.utils.portage:get_last_version:572 - Convert Tag: v0.10.1 -> 0.10.1
2026-04-27 20:46:46,795 | DEBUG    | livecheck.utils.portage:get_last_version:572 - Convert Tag: v3.6.10 -> 3.6.10
2026-04-27 20:46:46,795 | DEBUG    | livecheck.utils.portage:get_last_version:572 - Convert Tag: v3.6.9 -> 3.6.9
2026-04-27 20:46:46,795 | DEBUG    | livecheck.utils.portage:get_last_version:572 - Convert Tag: v3.7.1 -> 3.7.1
2026-04-27 20:46:46,795 | DEBUG    | livecheck.utils.portage:get_last_version:572 - Convert Tag: v3.7.0 -> 3.7.0
2026-04-27 20:46:46,795 | DEBUG    | livecheck.utils.portage:get_last_version:572 - Convert Tag: v3.6.8 -> 3.6.8
2026-04-27 20:46:46,795 | DEBUG    | livecheck.utils.portage:get_last_version:572 - Convert Tag: v0.10.0 -> 0.10.0
2026-04-27 20:46:46,795 | DEBUG    | livecheck.utils.portage:get_last_version:572 - Convert Tag: v3.5.12 -> 3.5.12
2026-04-27 20:46:46,796 | DEBUG    | livecheck.utils.requests:get_content:145 - Fetching https://api.github.com/repos/grafana/loki/git/refs/tags/v3.7.1
2026-04-27 20:46:46,796 | DEBUG    | niquests_cache.session:_log_backend:218 - Using backend `niquests_cache.backends.sqlite.SQLiteBackend`. Path: /home/fran/.cache/livecheck/http.sqlite
2026-04-27 20:46:46,860 | DEBUG    | urllib3_future._async.connectionpool:_new_conn:2169 - Starting new HTTPS connection (1): api.github.com:443
2026-04-27 20:46:47,254 | DEBUG    | urllib3_future._async.connectionpool:_make_request:1453 - https://api.github.com:443 "GET /repos/grafana/loki/git/refs/tags/v3.7.1 HTTP/2.0" 200 None
2026-04-27 20:46:47,255 | DEBUG    | livecheck.main:_check_one_package:506 - Inserting app-admin/loki: 3.7.1 -> 3.7.1 : 
2026-04-27 20:46:47,255 | INFO     | livecheck.main:_bounded:564 - Progress: 1/1 packages checked.
2026-04-27 20:46:47,255 | DEBUG    | livecheck.main:do_main:719 - top_hash = 3.7.1
2026-04-27 20:46:47,255 | DEBUG    | livecheck.main:do_main:724 - Comparing current ebuild version 3.7.1 with live version 3.7.1.
</pre>